### PR TITLE
TER-73 omit same module input output mappings

### DIFF
--- a/src/pkg/db/resource_attributes.go
+++ b/src/pkg/db/resource_attributes.go
@@ -24,8 +24,8 @@ type TFResourceAttribute struct {
 
 func (a TFResourceAttribute) GetConnectedModuleOutputs() TFModuleAttributes {
 	resp := TFModuleAttributes{}
-	for _, mappings := range a.OutputMappings {
-		resp = append(resp, mappings.OutputAttribute.RelatedModuleAttrs...)
+	for _, om := range a.OutputMappings {
+		resp = append(resp, om.OutputAttribute.RelatedModuleAttrs...)
 	}
 	return resp
 }


### PR DESCRIPTION
This change omits the input-output mappings between attributes of the same module.
To do this, we add a query hook in GORM to filter out these mappings from the response.