### PR TITLE
TER-112 added dir and file flags to cli commands

### DIFF
--- a/src/cli/cmd/farm/mappings/mappings.go
+++ b/src/cli/cmd/farm/mappings/mappings.go
@@ -3,29 +3,36 @@ package mappings
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	"github.com/cldcvr/terrarium/src/cli/internal/config"
+	"github.com/cldcvr/terrarium/src/cli/internal/constants"
 	"github.com/cldcvr/terrarium/src/pkg/db"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 )
 
-const moduleSchemaFilePath = "terraform/.terraform/modules/modules.json"
-
 var resourceTypeByName map[string]*db.TFResourceType
 
+var moduleDirectoryFlag string
+
 func GetCmd() *cobra.Command {
+	addFlags()
 	return mappingsCmd
 }
 
 var mappingsCmd = &cobra.Command{
 	Use:   "mappings",
 	Short: "Scrapes resource attribute mappings from the farm directory",
-	Long:  "The 'mappings' command scrapes resource attribute mappings fromthe specified farm directory.",
+	Long:  "The 'mappings' command scrapes resource attribute mappings from the specified farm directory.",
 	Run: func(cmd *cobra.Command, args []string) {
 		main()
 	},
+}
+
+func addFlags() {
+	mappingsCmd.Flags().StringVarP(&moduleDirectoryFlag, "dir", "d", "terraform", "farm directory path")
 }
 
 func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Resource, dstResInputName string, srcRes tfconfig.AttributeReference) (*db.TFResourceAttributesMapping, error) {
@@ -137,7 +144,7 @@ func main() {
 
 	resourceTypeByName = make(map[string]*db.TFResourceType)
 	log.Println("Loading modules...")
-	configs, _, err := tfconfig.LoadModulesFromResolvedSchema(moduleSchemaFilePath)
+	configs, _, err := tfconfig.LoadModulesFromResolvedSchema(filepath.Join(moduleDirectoryFlag, constants.ModuleSchemaFilePath))
 	if err != nil {
 		panic(err)
 	}

--- a/src/cli/cmd/farm/modules/modules.go
+++ b/src/cli/cmd/farm/modules/modules.go
@@ -3,15 +3,17 @@ package modules
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	"github.com/cldcvr/terrarium/src/cli/internal/config"
+	"github.com/cldcvr/terrarium/src/cli/internal/constants"
 	"github.com/cldcvr/terrarium/src/pkg/db"
 	"github.com/spf13/cobra"
 )
 
-const moduleSchemaFilePath = "terraform/.terraform/modules/modules.json"
+var moduleDirectoryFlag string
 
 var resourceTypeByName map[string]*db.TFResourceType
 
@@ -32,7 +34,12 @@ var modulesCmd = &cobra.Command{
 }
 
 func GetCmd() *cobra.Command {
+	addFlags()
 	return modulesCmd
+}
+
+func addFlags() {
+	modulesCmd.Flags().StringVarP(&moduleDirectoryFlag, "dir", "d", "terraform", "farm directory path")
 }
 
 func createAttributeRecord(g db.DB, moduleDB *db.TFModule, v tfValue, varAttributePath string, res tfconfig.AttributeReference) (*db.TFModuleAttribute, error) {
@@ -102,7 +109,7 @@ func main() {
 	// load modules
 	log.Println("Loading modules...")
 
-	configs, _, err := tfconfig.LoadModulesFromResolvedSchema(moduleSchemaFilePath, tfconfig.FilterModulesOmitLocal, tfconfig.FilterModulesOmitHidden)
+	configs, _, err := tfconfig.LoadModulesFromResolvedSchema(filepath.Join(moduleDirectoryFlag, constants.ModuleSchemaFilePath), tfconfig.FilterModulesOmitLocal, tfconfig.FilterModulesOmitHidden)
 	if err != nil {
 		panic(err)
 	}

--- a/src/cli/cmd/farm/resources/resources.go
+++ b/src/cli/cmd/farm/resources/resources.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var moduleSchemaFilePathFlag string
+
 var resourcesCmd = &cobra.Command{
 	Use:   "resources",
 	Short: "Scrapes Terraform resources and attributes from the farm directory",
@@ -23,7 +25,12 @@ var resourcesCmd = &cobra.Command{
 }
 
 func GetCmd() *cobra.Command {
+	addFlags()
 	return resourcesCmd
+}
+
+func addFlags() {
+	resourcesCmd.Flags().StringVarP(&moduleSchemaFilePathFlag, "file", "f", "cache_data/tf_resources.json", "schema file path")
 }
 
 func main() {
@@ -32,7 +39,7 @@ func main() {
 	mustNotErr(err, "Error connecting to the database")
 
 	// Load providers schema from file
-	providersSchema, err := loadProvidersSchema("cache_data/tf_resources.json")
+	providersSchema, err := loadProvidersSchema(moduleSchemaFilePathFlag)
 	mustNotErr(err, "Error loading providers schema")
 
 	pushProvidersSchemaToDB(providersSchema, db)

--- a/src/cli/internal/constants/constants.go
+++ b/src/cli/internal/constants/constants.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	ModuleSchemaFilePath = ".terraform/modules/modules.json"
+)


### PR DESCRIPTION
``ter farm resources --file <resource-json-file-path> ``

if not given, default is ``cache_data/tf_resources.json``

``ter farm modules --dir <terraform-directory>``

the terraform directory represents the path where terraform code resides and terraform init has been performed.
The command looks for modules.json on path ``<terraform-directory>/.terraform/modules/modules.json``

if not given, default is ``terraform``. So the default path becomes ``terraform/.terraform/modules/modules.json``

It is applicable to mappings as well.
``ter farm mappings --dir <terraform-directory>``