### PR TITLE
TER-113 added local modules indexing support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,9 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/src/cli/main.go",
+      "program": "${workspaceFolder}/src/cli/terrarium/main.go",
       "args": [
-        "farm",
+        "harvest",
         "resources"
       ],
       "envFile": "${workspaceFolder}/.env",
@@ -22,10 +22,13 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/src/cli/main.go",
+      "program": "${workspaceFolder}/src/cli/terrarium/main.go",
       "args": [
-        "farm",
-        "modules"
+        "harvest",
+        "modules",
+        "-d",
+        "examples/farm/modules", // terraform directory
+        "-l" // include local
       ],
       "envFile": "${workspaceFolder}/.env",
       "cwd": "${workspaceFolder}",
@@ -35,10 +38,12 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/src/cli/main.go",
+      "program": "${workspaceFolder}/src/cli/terrarium/main.go",
       "args": [
-        "farm",
-        "mappings"
+        "harvest",
+        "mappings",
+        "-d",
+        "examples/farm/modules", // terraform directory
       ],
       "envFile": "${workspaceFolder}/.env",
       "cwd": "${workspaceFolder}",
@@ -48,7 +53,7 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/src/cli/main.go",
+      "program": "${workspaceFolder}/src/cli/terrarium/main.go",
       "args": [
         "platform",
         "lint",

--- a/src/cli/cmd/harvest/mappings/mappings.go
+++ b/src/cli/cmd/harvest/mappings/mappings.go
@@ -32,7 +32,7 @@ var mappingsCmd = &cobra.Command{
 }
 
 func addFlags() {
-	mappingsCmd.Flags().StringVarP(&moduleDirectoryFlag, "dir", "d", "terraform", "farm directory path")
+	mappingsCmd.Flags().StringVarP(&moduleDirectoryFlag, "dir", "d", "", "farm directory path")
 }
 
 func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Resource, dstResInputName string, srcRes tfconfig.AttributeReference) (*db.TFResourceAttributesMapping, error) {

--- a/src/cli/internal/constants/constants.go
+++ b/src/cli/internal/constants/constants.go
@@ -1,5 +1,6 @@
 package constants
 
 const (
-	ModuleSchemaFilePath = ".terraform/modules/modules.json"
+	ModuleSchemaFilePath      = ".terraform/modules/modules.json"
+	DefaultExampleTFDirectory = "examples/farm/modules"
 )

--- a/src/pkg/db/module.go
+++ b/src/pkg/db/module.go
@@ -21,6 +21,7 @@ type TFModule struct {
 	Version     Version `gorm:"uniqueIndex:module_unique"`
 	Description string
 	TaxonomyID  uuid.UUID `gorm:"default:null"`
+	Namespace   string    `gorm:"default:farm_repo"`
 
 	Taxonomy   *Taxonomy           `gorm:"foreignKey:TaxonomyID"`
 	Attributes []TFModuleAttribute `gorm:"foreignKey:ModuleID"` // Attributes of the module


### PR DESCRIPTION
- added a column for namespace. by default the namespace would be ``farm_repo``

- in case of local modules it would be directory from where the modules are referenced.

- added flag to support indexing local modules. example usage:

``ter harvest modules --dir <tf-dir> -l ``
OR
``ter harvest modules --dir <tf-dir> --enable-local-modules``

it will index the local modules referenced into the directory and persist the path as namespace.

- updated debugging configurations