### PR TITLE
TER-137 add missing gh token in the pipeline

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -3,9 +3,11 @@ name: Run CI Checks
 on:
   pull_request:
     branches: ["main"]
+  push:
+    branches: ["main"]
 
 env:
-  TR_DB_PASSWORD: a_super_secret_sequence_of_ordinary_characters
+  TR_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
 jobs:
   checks:
@@ -16,12 +18,18 @@ jobs:
 
       - name: Check default Setup
         run: |
-          make docker-init
-          make farm-release-pull || echo "Terrarium farm release not found. Skipping farm DB check"
-          make docker-build docker-run
-          sleep 10
-          curl --fail -s http://localhost:3000/v0/healthcheck
-          make docker-stop-clean
+          make farm-release-pull
+          make docker-init docker-build docker-run
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+      - name: API Health Check
+        uses: jtalk/url-health-check-action@v3
+        with:
+          url: http://localhost:3000/v0/healthcheck
+          max-attempts: 60
+          retry-delay: 1s
+          retry-all: true
 
       - name: Run unit tests
         run: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,8 @@ services:
     build:
       context: .
       target: api-runner
+      cache_from:
+        - "cldcvr/terrarium-api:latest"
     environment:
       # DB config
       TR_DB_HOST: ${TR_DB_HOST:-postgres}
@@ -50,6 +52,8 @@ services:
       TR_LOG_PRETTY_PRINT: ${TR_LOG_PRETTY_PRINT:-true}
     ports:
       - ${TR_SERVER_HTTP_PORT:-3000}:3000
+    depends_on:
+      - postgres
 
   farm-harvester:
     image: cldcvr/terrarium-farm-harvester
@@ -60,6 +64,8 @@ services:
       target: farm-harvester
       args:
         TERRAFORM_VERSION: ${TERRAFORM_VERSION:-latest}
+      cache_from:
+        - "cldcvr/terrarium-farm-harvester:latest"
     secrets:
       - source: netrc
         target: /root/.netrc
@@ -74,6 +80,8 @@ services:
       - ./examples/farm:/app/farm
     profiles:
       - tooling
+    depends_on:
+      - postgres
 
   terrarium-unit-test:
     image: cldcvr/terrarium-unit-test

--- a/setup.md
+++ b/setup.md
@@ -6,6 +6,7 @@ Before you begin, ensure you have the following installed:
 
 - Go version >= 1.20
 - Docker & Docker Compose CLI
+- GitHub cli (gh)
 
 ## Environment Variables
 


### PR DESCRIPTION
This change fixes the missing GitHub token in the in the checks pipeline required to download the terrarium-farm release asset.

Additionally:

- Update setup.md to add GitHub CLI in prerequisite.
- Update docker-compose.yaml to add clear dependency between services. And optimise for cache reuse.