### PR TITLE
TER-187 fixed namespace ingestion

### DIFF
--- a/src/cli/cmd/harvest/modules/modules.go
+++ b/src/cli/cmd/harvest/modules/modules.go
@@ -2,7 +2,7 @@ package modules
 
 import (
 	"fmt"
-	"os/exec"
+	"os"
 	"strings"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
@@ -85,9 +85,8 @@ func toTFModule(config *tfconfig.Module) *db.TFModule {
 		// filter local module
 		if flagIncludeLocal && strings.HasPrefix(config.Metadata.Source, ".") && config.Metadata.Name != "" {
 			if strings.TrimSpace(flagTFDir) == "." || strings.TrimSpace(flagTFDir) == "" {
-				cmd := exec.Command("pwd")
-				dir, _ := cmd.CombinedOutput()
-				flagTFDir = string(dir)
+				cwd, _ := os.Getwd()
+				flagTFDir = strings.TrimRight(cwd, "\n")
 			}
 			record.Namespace = flagTFDir
 		}


### PR DESCRIPTION
in case when terraform directory is not provided while ingesting local modules, we were fetching the current directory. In process of that we were persisting an additional newline char which was causing failure to fetch the record.