### PR TITLE
TER-195 Add way to farm TF modules one-by-one

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,10 @@
       "args": [
         "harvest",
         "resources",
-        "-f${workspaceFolder}/examples/farm/modules/.terraform/providers/schema.json"
+        "-s",
+        "${workspaceFolder}/examples/farm/modules/.terraform/providers/schema.json",
+        // "-f",
+        // "examples/farm/modules.yaml", // terraform modules list
       ],
       "envFile": "${workspaceFolder}/.env",
       "cwd": "${workspaceFolder}",
@@ -42,6 +45,8 @@
         "modules",
         "-d",
         "examples/farm/modules", // terraform directory
+        // "-f",
+        // "examples/farm/modules.yaml", // terraform modules list
         "-l" // include local
       ],
       "envFile": "${workspaceFolder}/.env",
@@ -58,6 +63,8 @@
         "mappings",
         "-d",
         "examples/farm/modules", // terraform directory
+        // "-f",
+        // "examples/farm/modules.yaml", // terraform modules list
       ],
       "envFile": "${workspaceFolder}/.env",
       "cwd": "${workspaceFolder}",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,25 +1,25 @@
 {
-    "go.toolsEnvVars": {
-      "GOPRIVATE": "github.com/cldcvr/*",
-      "GO111MODULE": "on",
-    },
-    "go.testTimeout": "600s",
-    "go.testEnvFile": "${workspaceFolder}/.env",
-    "go.testTags": "dbtest",
-    // "go.buildTags": "dbtest", // uncomment this only while working on unit-test
-    "go.testFlags": [
-      "-v",
-      "-count=1"
-    ],
-    "protoc": {
-      "compile_on_save": true,
-      "options": [
-        "-I=${workspaceRoot}/src/pkg/pb",
-        "-I/usr/local/include",
-        "-I${workspaceRoot}",
-        "--go-grpc_out=/tmp",
-        "--plugin=protoc-gen-grpc=grpc_go_plugin",
-        "--go_out=/tmp"
-      ]
-    },
+  "go.toolsEnvVars": {
+    "GOPRIVATE": "github.com/cldcvr/*",
+    "GO111MODULE": "on",
+  },
+  "go.testTimeout": "600s",
+  "go.testEnvFile": "${workspaceFolder}/.env",
+  "go.testTags": "dbtest,mock",
+  // "go.buildTags": "dbtest", // uncomment this only while working on unit-test
+  "go.testFlags": [
+    "-v",
+    "-count=1"
+  ],
+  "protoc": {
+    "compile_on_save": true,
+    "options": [
+      "-I=${workspaceRoot}/src/pkg/pb",
+      "-I/usr/local/include",
+      "-I${workspaceRoot}",
+      "--go-grpc_out=/tmp",
+      "--plugin=protoc-gen-grpc=grpc_go_plugin",
+      "--go_out=/tmp"
+    ]
+  },
 }

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ mod-tidy:  ## run go mod tidy on each workspace entity, and then sync workspace
 .PHONY: test
 test:  ## Run go unit tests
 	mkdir -p coverage
-	go test -coverprofile $(COVERAGE_FILE) github.com/cldcvr/terrarium/...
+	go test -v -tags=mock -coverprofile $(COVERAGE_FILE) github.com/cldcvr/terrarium/...
 	@echo "-- Test coverage for terrarium --"
 	@go tool cover -func=$(COVERAGE_FILE)|grep "total:"
 
@@ -196,7 +196,7 @@ farm-harvest: farm-resource-harvest farm-module-harvest farm-mapping-harvest  ##
 
 .PHONY: farm-resource-harvest
 farm-resource-harvest: $(FARM_MODULES_DIR)/.terraform/providers/schema.json  ## Harvest terraform provider resources from the farm directory
-	terrarium harvest resources -f $(FARM_MODULES_DIR)/.terraform/providers/schema.json
+	terrarium harvest resources -s $(FARM_MODULES_DIR)/.terraform/providers/schema.json
 
 .PHONY: farm-module-harvest  ## Harvest terraform modules from the farm directory
 farm-module-harvest: $(FARM_MODULES_DIR)/.terraform

--- a/examples/farm/modules.yaml
+++ b/examples/farm/modules.yaml
@@ -1,0 +1,37 @@
+farm:
+  - name: eks
+    source: "terraform-aws-modules/eks/aws"
+    version: "18.31.2"
+    export: true
+  - name: vpc
+    source: "terraform-aws-modules/vpc/aws"
+    version: "4.0.2"
+    export: true
+  - name: security-group
+    source: "terraform-aws-modules/security-group/aws"
+    version: "5.1.0"
+    export: true
+  - name: rds
+    source: "terraform-aws-modules/rds/aws"
+    version: "5.1.1"
+    export: true
+  - name: kms
+    source: "terraform-aws-modules/kms/aws"
+    version: "1.5.0"
+    export: true
+  - name: cloudwatch-kms-key
+    source: "dod-iac/cloudwatch-kms-key/aws"
+    version: "1.0.1"
+    export: true
+  - name: banking-demo
+    source: "github.com/cldcvr/codepipes-tutorials//tfs/aws-ecr-apprunner-vpc?ref=terrarium-sources"
+    export: false
+  - name: voting-demo
+    source: "github.com/cldcvr/codepipes-tutorials//voting/infra/aws/eks?ref=terrarium-sources"
+    export: false
+  - name: serverless-sample
+    source: "github.com/cldcvr/codepipes-tutorials//serverless-sample/infra/aws?ref=terrarium-sources"
+    export: false
+  - name: wpdemo-eks
+    source: "github.com/cldcvr/codepipes-tutorials//wpdemo/infra/aws/eks?ref=terrarium-sources"
+    export: false

--- a/examples/farm/readme.md
+++ b/examples/farm/readme.md
@@ -25,6 +25,12 @@ module "tr-hide-banking-demo" {
 }
 ```
 
+## Harvesting Multiple Modules
+
+To avoid provider version conflicts when harvesting multiple modules at once the user may provide a file containing a list of modules to be processed by the `harvest` commands. The commands then process each module in a separate workspace while performing the required Terraform initialization automatically.
+
+Read more - [src/pkg/metadata/cli/readme.md](./src/pkg/metadata/cli/readme.md)
+
 ## Terrarium Farm Dependency Interfaces
 
 The Terrarium Dependency Interface is a contract that defines the inputs and outputs of an infrastructure dependency, facilitating communication between applications and Infrastructure as Code (IaC). It enables multi-platform implementation and is a key component in the Terrarium project architecture.

--- a/src/cli/cmd/harvest/mappings/mappings.go
+++ b/src/cli/cmd/harvest/mappings/mappings.go
@@ -9,11 +9,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var resourceTypeByName map[string]*db.TFResourceType
-
-func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Resource, dstResInputName string, srcRes tfconfig.AttributeReference) (*db.TFResourceAttributesMapping, error) {
+func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Resource, dstResInputName string, srcRes tfconfig.AttributeReference, resourceTypeByNameCache map[string]*db.TFResourceType) (*db.TFResourceAttributesMapping, error) {
 	if !slices.Contains([]string{"", "module", "var", "local", "each"}, srcRes.Type()) && srcRes.Path() != "" {
-		srcResDB, ok := resourceTypeByName[srcRes.Type()]
+		srcResDB, ok := resourceTypeByNameCache[srcRes.Type()]
 		if !ok {
 			srcResDB = &db.TFResourceType{}
 			if err := g.GetTFResourceType(srcResDB, &db.TFResourceType{
@@ -22,7 +20,7 @@ func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Reso
 			}); err != nil {
 				return nil, nil // skip unknown resources (e.g. need to populate more resource types)
 			}
-			resourceTypeByName[srcRes.Type()] = srcResDB
+			resourceTypeByNameCache[srcRes.Type()] = srcResDB
 		}
 
 		srcAttrDB := &db.TFResourceAttribute{}
@@ -36,7 +34,7 @@ func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Reso
 			return nil, nil // skip unknown resource attributes (e.g. reference to field in a dynamic type)
 		}
 
-		dstResDB, ok := resourceTypeByName[dstRes.Type]
+		dstResDB, ok := resourceTypeByNameCache[dstRes.Type]
 		if !ok {
 			dstResDB = &db.TFResourceType{}
 			if err := g.GetTFResourceType(dstResDB, &db.TFResourceType{
@@ -45,7 +43,7 @@ func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Reso
 			}); err != nil {
 				return nil, nil // skip unknown resources (e.g. need to populate more resource types)
 			}
-			resourceTypeByName[dstRes.Type] = dstResDB
+			resourceTypeByNameCache[dstRes.Type] = dstResDB
 		}
 
 		dstAttrDB := &db.TFResourceAttribute{}
@@ -73,13 +71,13 @@ func fmtAttrMeta(resType string, resName string, resAttr string, resFile string,
 	return fmt.Sprintf("[resource='%s.%s'; attribute='%s'; file='%s'; line=%d]", resType, resName, resAttr, resFile, resLine)
 }
 
-func createMappingsForResources(g db.DB, parent *tfconfig.Module, resources map[string]*tfconfig.Resource, created *[]*db.TFResourceAttributesMapping) (resourceCount int, err error) {
+func createMappingsForResources(g db.DB, parent *tfconfig.Module, resources map[string]*tfconfig.Resource, created *[]*db.TFResourceAttributesMapping, resourceTypeByNameCache map[string]*db.TFResourceType) (resourceCount int, err error) {
 	for dstResName, dstRes := range resources {
 		log.Infof("Processing resource declaration '%s'...\n", dstResName)
 		resourceMallingCount := 0
 		for dstResInputName, inputValueReferences := range dstRes.References {
 			for _, item := range inputValueReferences {
-				mapping, err := createMappingRecord(g, parent, dstRes, dstResInputName, item)
+				mapping, err := createMappingRecord(g, parent, dstRes, dstResInputName, item, resourceTypeByNameCache)
 				if err != nil {
 					return 0, err
 				}
@@ -92,16 +90,16 @@ func createMappingsForResources(g db.DB, parent *tfconfig.Module, resources map[
 	return len(resources), nil
 }
 
-func createMappingsForModule(g db.DB, config *tfconfig.Module) (mappings []*db.TFResourceAttributesMapping, resourceCount int, err error) {
+func createMappingsForModule(g db.DB, config *tfconfig.Module, resourceTypeByNameCache map[string]*db.TFResourceType) (mappings []*db.TFResourceAttributesMapping, resourceCount int, err error) {
 	log.Infof("Processing module '%s'...\n", config.Path)
 	mappings = make([]*db.TFResourceAttributesMapping, 0)
-	count, err := createMappingsForResources(g, config, config.ManagedResources, &mappings)
+	count, err := createMappingsForResources(g, config, config.ManagedResources, &mappings, resourceTypeByNameCache)
 	if err != nil {
 		return nil, 0, err
 	}
 	resourceCount += count
 
-	count, err = createMappingsForResources(g, config, config.DataResources, &mappings)
+	count, err = createMappingsForResources(g, config, config.DataResources, &mappings, resourceTypeByNameCache)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -110,7 +108,7 @@ func createMappingsForModule(g db.DB, config *tfconfig.Module) (mappings []*db.T
 	// process sub-modules
 	for _, dstMod := range config.ModuleCalls {
 		if dstMod.Module != nil {
-			subMappings, subResCount, err := createMappingsForModule(g, dstMod.Module)
+			subMappings, subResCount, err := createMappingsForModule(g, dstMod.Module, resourceTypeByNameCache)
 			if err != nil {
 				return subMappings, subResCount, err
 			}

--- a/src/cli/internal/config/defaults.yaml
+++ b/src/cli/internal/config/defaults.yaml
@@ -26,3 +26,5 @@ log:
   format: "text"
   level: "info" # debug | info | warn | error | fatal
 
+terraform:
+  plugin_cache_dir: "~/.terraform.d/plugin-cache"

--- a/src/pkg/commander/commander.go
+++ b/src/pkg/commander/commander.go
@@ -1,0 +1,9 @@
+package commander
+
+import "os/exec"
+
+type osExec struct{}
+
+func (e *osExec) Run(cmd *exec.Cmd) error {
+	return cmd.Run()
+}

--- a/src/pkg/commander/factory.go
+++ b/src/pkg/commander/factory.go
@@ -1,0 +1,8 @@
+//go:build !mock
+// +build !mock
+
+package commander
+
+func GetCommander() Commander {
+	return &osExec{}
+}

--- a/src/pkg/commander/iface.go
+++ b/src/pkg/commander/iface.go
@@ -1,0 +1,7 @@
+package commander
+
+import "os/exec"
+
+type Commander interface {
+	Run(*exec.Cmd) error
+}

--- a/src/pkg/commander/mock_factory.go
+++ b/src/pkg/commander/mock_factory.go
@@ -1,0 +1,14 @@
+//go:build mock
+// +build mock
+
+package commander
+
+var m Commander
+
+func SetCommander(mock Commander) {
+	m = mock
+}
+
+func GetCommander() Commander {
+	return m
+}

--- a/src/pkg/metadata/cli/example.yaml
+++ b/src/pkg/metadata/cli/example.yaml
@@ -1,0 +1,8 @@
+farm:
+  - name: vpc # REQUIRED: unique user-defined module name (will be used as name for exported modules)
+    source: "terraform-aws-modules/vpc/aws" # REQUIRED: Terraform module source
+    version: "4.0.2" # OPTIONAL: Terraform module version
+    export: true # OPTIONAL: if true the module can be imported to the module library, otherwise it will be used only in discovery of resource attributes and mappings
+  - name: voting-demo
+    source: "github.com/cldcvr/codepipes-tutorials//voting/infra/aws/eks?ref=terrarium-sources"
+    export: false # this modules will only be used to discover resource attributes and mappings between resources

--- a/src/pkg/metadata/cli/model.go
+++ b/src/pkg/metadata/cli/model.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type FarmModuleRef struct {
+	Name    string `yaml:"name"`
+	Source  string `yaml:"source"`
+	Version string `yaml:"version,omitempty"`
+	Export  bool   `yaml:"export,omitempty"`
+}
+
+func (r FarmModuleRef) CreateTerraformFile() (dirPath string, filePath string, err error) {
+	dirPath, err = os.MkdirTemp("", fmt.Sprintf("tr_%s_*", r.Name))
+	if err != nil {
+		return "", "", fmt.Errorf("could not create output directory: %w", err)
+	}
+	fp, err := os.Create(path.Join(dirPath, "main.tf"))
+	if err != nil {
+		return "", "", fmt.Errorf("could not open output file: %w", err)
+	}
+	defer fp.Close()
+	if _, err := fp.WriteString(r.ToTerraform()); err != nil {
+		return "", "", fmt.Errorf("could not write to output file '%s': %w", fp.Name(), err)
+	}
+
+	filePath = fp.Name()
+	return
+}
+
+func (r FarmModuleRef) ToTerraform() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("module \"%s\" {\n", r.Name))
+	b.WriteString(fmt.Sprintf("	source = \"%s\"\n", r.Source))
+	if r.Version != "" {
+		b.WriteString(fmt.Sprintf("	version = \"%s\"\n", r.Version))
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+type FarmModuleList struct {
+	Farm []FarmModuleRef `yaml:"farm"`
+}
+
+func LoadFarmModules(listFilePath string) (FarmModuleList, error) {
+	moduleList, err := loadFarmModules(listFilePath)
+	if err != nil {
+		return moduleList, fmt.Errorf("failed to load farm module list file '%s': %w", listFilePath, err)
+	}
+	if err := moduleList.Validate(); err != nil {
+		return moduleList, fmt.Errorf("farm module list file '%s' has invalid items: %w", listFilePath, err)
+	}
+	return moduleList, nil
+}
+
+func loadFarmModules(listFilePath string) (moduleList FarmModuleList, err error) {
+	listFile, err := os.ReadFile(listFilePath)
+	if err != nil {
+		return
+	}
+	if err = yaml.Unmarshal(listFile, &moduleList); err != nil {
+		return
+	}
+	return
+}
+
+func (l FarmModuleList) Validate() error {
+	itemCount := len(l.Farm)
+	uniqueModuleReferences := make(map[string]*FarmModuleRef, itemCount)
+	uniqueExportNames := make(map[string]int, itemCount)
+	for i, item := range l.Farm {
+		if item.Name == "" {
+			return fmt.Errorf("module at index %d must have a unique name", i)
+		}
+		if item.Source == "" {
+			return fmt.Errorf("module '%s' must have a source", item.Name)
+		}
+		if _, exists := uniqueExportNames[item.Name]; exists {
+			return fmt.Errorf("module '%s' at index %d has a duplicate name", item.Name, i)
+		}
+		uniqueExportNames[item.Name] = i
+		refKey := fmt.Sprintf("%s@%s", item.Source, item.Version)
+		if found, exists := uniqueModuleReferences[refKey]; exists {
+			return fmt.Errorf("module '%s' is duplicate of module '%s'", item.Name, found.Name)
+		}
+		uniqueModuleReferences[refKey] = &item
+	}
+	return nil
+}

--- a/src/pkg/metadata/cli/model_test.go
+++ b/src/pkg/metadata/cli/model_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import "testing"
+
+func TestFarmModuleList_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		list    FarmModuleList
+		wantErr bool
+	}{
+		{
+			name: "duplicate export name",
+			list: FarmModuleList{
+				Farm: []FarmModuleRef{
+					{
+						Source:  "http://rowdy-watcher.info",
+						Version: "4.5.6",
+						Name:    "solution",
+					},
+					{
+						Source:  "https://knobby-courtroom.net",
+						Version: "1.2.3",
+						Name:    "solution",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate reference",
+			list: FarmModuleList{
+				Farm: []FarmModuleRef{
+					{
+						Source:  "http://bite-sized-scrap.org",
+						Version: "9.4.6",
+						Name:    "Wooden",
+					},
+					{
+						Source:  "http://bite-sized-scrap.org",
+						Version: "9.4.6",
+						Name:    "navigate",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid module list",
+			list: FarmModuleList{
+				Farm: []FarmModuleRef{
+					{
+						Source:  "http://defiant-forum.com",
+						Version: "0.0.0",
+						Name:    "Concrete",
+					},
+					{
+						Source:  "https://heavy-caviar.name",
+						Version: "21.5.4",
+						Name:    "synthesizing",
+					},
+					{
+						Source:  "http://cultured-subscription.com",
+						Version: "8.8.8",
+						Name:    "generating",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.list.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("FarmModuleList.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/src/pkg/metadata/cli/readme.md
+++ b/src/pkg/metadata/cli/readme.md
@@ -1,0 +1,31 @@
+# Farm Module List File Format
+
+Module list can be used to provide Terraform modules to be loaded by CLI `harvest` commands.
+
+## Overview
+
+The client `harvest` commands can read Terraform files directly from a given directory path. The user is required to pre-initialize the working directory by running commands such as `terraform init`. This can lead to a version conflict if some of the loaded modules require incompatible provider versions.
+
+To avoid this caveat the user may instead pass in a file containing a list of modules to be loaded. The `harvest` commands then process each module in a separate workspace hence avoiding any version conflicts between different modules.
+
+In case of the module list file the CLI performs workspace initialization for each module on-the-fly. In order to improve performance it relies on the Terraform built-in plugin cache. The cache location can be controlled by `terraform.plugin_cache_dir` configuration variable pre-set to `~/.terraform.d/plugin-cache`.
+
+## Module List File Structure
+
+Each entry has a required `source` and an optional `version` attribute that maps to Terraform module call `source` and `version` attributes.
+In addition to these each may also declare a boolean `export` attribute. Only modules that set it to `true` will be processed by the `module-harvest` command - i.e. will be included in the user's module library.
+Finally each entry must declare a unique `name` identifier. This value will be used as exported module's name in the library.
+
+## Example Module List File
+
+```yaml
+farm:
+  - name: vpc # REQUIRED: unique user-defined module name (will be used as name for exported modules)
+    source: "terraform-aws-modules/vpc/aws" # REQUIRED: Terraform module source
+    version: "4.0.2" # OPTIONAL: Terraform module version
+    export: true # OPTIONAL: if true the module can be imported to the module library, otherwise it will be used only in discovery of resource attributes and mappings
+  - name: voting-demo
+    source: "github.com/cldcvr/codepipes-tutorials//voting/infra/aws/eks?ref=terrarium-sources"
+    export: false # this modules will only be used to discover resource attributes and mappings between resources
+
+```

--- a/src/pkg/tf/runner/run.go
+++ b/src/pkg/tf/runner/run.go
@@ -1,0 +1,81 @@
+package runner
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cldcvr/terrarium/src/pkg/commander"
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+)
+
+func NewTerraformRunner() *terraformRunner {
+	cacheDir := viper.GetString("terraform.plugin_cache_dir")
+	terraformDefaultEnv := []string{
+		"TF_IN_AUTOMATION=1",
+		"TF_INPUT=0",
+	}
+	if cacheDir != "" {
+		resolvedCacheDir, err := homedir.Expand(cacheDir)
+		if err != nil {
+			log.Fatalf("could not open user home directory: %v", err)
+		} else if err := os.MkdirAll(resolvedCacheDir, os.ModePerm); err != nil {
+			log.Fatalf("could not create Terraform plugin_cache_dir '%s': %v", resolvedCacheDir, err)
+		} else {
+			terraformDefaultEnv = append(terraformDefaultEnv, fmt.Sprintf("TF_PLUGIN_CACHE_DIR=%s", resolvedCacheDir))
+		}
+	}
+
+	return &terraformRunner{
+		terraformDefaultEnv: terraformDefaultEnv,
+	}
+}
+
+type terraformRunner struct {
+	terraformDefaultEnv []string
+}
+
+func (tr *terraformRunner) RunTerraformVersion() error {
+	return tr.runTerraformCommandWithDefaultEnv("", []string{"version"}, nil)
+}
+
+func (tr *terraformRunner) RunTerraformInit(dir string) error {
+	return tr.runTerraformCommandWithDefaultEnv(dir, []string{"init"}, nil)
+}
+
+func (tr *terraformRunner) RunTerraformProviders(dir string) error {
+	return tr.runTerraformCommandWithDefaultEnv(dir, []string{"providers"}, nil)
+}
+
+func (tr *terraformRunner) RunTerraformProvidersSchema(dir string, outFilePath string) error {
+	out, err := os.Create(outFilePath)
+	if err != nil {
+		return fmt.Errorf("could not open output file '%s': %w", outFilePath, err)
+	}
+	return tr.runTerraformCommandWithDefaultEnv(dir, []string{"providers", "schema", "-json"}, out)
+}
+
+func (tr *terraformRunner) runTerraformCommandWithDefaultEnv(dir string, args []string, outWriter io.Writer) error {
+	return tr.runTerraformCommand(dir, args, tr.terraformDefaultEnv, outWriter)
+}
+
+func (tr *terraformRunner) runTerraformCommand(dir string, args []string, env []string, outWriter io.Writer) error {
+	cmd := exec.Command("terraform", args...)
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Env, os.Environ()...) // inherit the user's ENV
+	cmd.Env = append(cmd.Env, env...)
+	if outWriter == nil {
+		outWriter = os.Stdout
+	}
+	cmd.Stdout = outWriter
+	cmd.Stderr = os.Stderr
+	log.Printf("[%s] %s", strings.Join(env, ", "), cmd.String())
+	if err := commander.GetCommander().Run(cmd); err != nil {
+		return fmt.Errorf("command '%v' finished with error: %v", cmd, err)
+	}
+	return nil
+}

--- a/src/pkg/tf/runner/run_test.go
+++ b/src/pkg/tf/runner/run_test.go
@@ -1,0 +1,165 @@
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/cldcvr/terrarium/src/pkg/commander"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockExec struct {
+	asserts func(*exec.Cmd)
+}
+
+func (m *mockExec) Run(cmd *exec.Cmd) error {
+	if m.asserts != nil {
+		m.asserts(cmd)
+	}
+	return nil
+}
+
+func Test_terraformRunner_RunTerraformVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "version",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commander.SetCommander(&mockExec{
+				asserts: func(cmd *exec.Cmd) {
+					assert.True(t, strings.HasSuffix(cmd.String(), "terraform version"))
+					assert.Same(t, os.Stdout, cmd.Stdout)
+				},
+			})
+			tr := NewTerraformRunner()
+			err := tr.RunTerraformVersion()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_terraformRunner_RunTerraformInit(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "init",
+			args: args{
+				dir: "bypassing",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commander.SetCommander(&mockExec{
+				asserts: func(cmd *exec.Cmd) {
+					assert.True(t, strings.HasSuffix(cmd.String(), "terraform init"))
+					assert.Same(t, os.Stdout, cmd.Stdout)
+					assert.Equal(t, tt.args.dir, cmd.Dir)
+				},
+			})
+			tr := NewTerraformRunner()
+			err := tr.RunTerraformInit(tt.args.dir)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_terraformRunner_RunTerraformProviders(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "providers",
+			args: args{
+				dir: "Cambridgeshire",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commander.SetCommander(&mockExec{
+				asserts: func(cmd *exec.Cmd) {
+					assert.True(t, strings.HasSuffix(cmd.String(), "terraform providers"))
+					assert.Same(t, os.Stdout, cmd.Stdout)
+					assert.Equal(t, tt.args.dir, cmd.Dir)
+				},
+			})
+			tr := NewTerraformRunner()
+			err := tr.RunTerraformProviders(tt.args.dir)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_terraformRunner_RunTerraformProvidersSchema(t *testing.T) {
+	mockOut, err := os.CreateTemp("", "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	type args struct {
+		dir         string
+		outFilePath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "bad out-file",
+			args: args{
+				dir:         "Berkshire",
+				outFilePath: path.Join(os.TempDir(), "ae66e499-9185-4639-a02a-79f870e1dce9", "d4285cd7-915f-4aa8-a193-9e6db7a033f0"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "providers schema",
+			args: args{
+				dir:         "Lanka",
+				outFilePath: mockOut.Name(),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commander.SetCommander(&mockExec{
+				asserts: func(cmd *exec.Cmd) {
+					assert.True(t, strings.HasSuffix(cmd.String(), "terraform providers schema -json"))
+					assert.Equal(t, tt.args.outFilePath, cmd.Stdout.(*os.File).Name())
+					assert.Equal(t, tt.args.dir, cmd.Dir)
+				},
+			})
+			tr := NewTerraformRunner()
+			err := tr.RunTerraformProvidersSchema(tt.args.dir, tt.args.outFilePath)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/src/pkg/tf/runner/utils.go
+++ b/src/pkg/tf/runner/utils.go
@@ -1,0 +1,23 @@
+package runner
+
+func TerraformProviderSchema(runner *terraformRunner, dir string, outFilePath string) error {
+	if err := TerraformInit(runner, dir); err != nil {
+		return err
+	}
+	if err := runner.RunTerraformProvidersSchema(dir, outFilePath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TerraformInit(runner *terraformRunner, dir string) error {
+	if err := runner.RunTerraformVersion(); err != nil {
+		return err
+	}
+	if err := runner.RunTerraformInit(dir); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/src/pkg/tf/runner/utils_test.go
+++ b/src/pkg/tf/runner/utils_test.go
@@ -1,0 +1,62 @@
+package runner
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/cldcvr/terrarium/src/pkg/commander"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerraformProviderSchema(t *testing.T) {
+	type args struct {
+		dir         string
+		outFilePath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "providers schema",
+			args: args{
+				dir:         os.TempDir(),
+				outFilePath: path.Join(os.TempDir(), "166e4331-7d85-4c0c-8d8a-3587a8ef95b9"),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		commander.SetCommander(&mockExec{})
+		tr := NewTerraformRunner()
+		err := TerraformProviderSchema(tr, tt.args.dir, tt.args.outFilePath)
+		assert.NoError(t, err)
+	}
+}
+
+func TestTerraformInit(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "providers schema",
+			args: args{
+				dir: "Avon",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		commander.SetCommander(&mockExec{})
+		tr := NewTerraformRunner()
+		err := TerraformInit(tr, tt.args.dir)
+		assert.NoError(t, err)
+	}
+}


### PR DESCRIPTION
In addition to existing harvest command parameters
allow specifying '-f modules.yaml'.

The modules file allows specifying multiple modules
to load.

```
farm:
  - name: eks
    source: "terraform-aws-modules/eks/aws"
    version: "18.31.2"
    export: true
```

This does not require pre-initializing the workspace as
the required Terraform commands get executed as needed.

Each module is loaded in a separate session hence avoiding
plugin version conflicts with other modules.

All modules are used to discover resources and resource-attribute
mappings.
The modules that have ```export: true``` get also loaded to
the module library.

In order to maintain consistency with other commands
harvest resource '-f' was changed to '-s'.