### PR TITLE
TER-171 Check dir path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -79,7 +79,7 @@
         "platform",
         "lint",
         "--dir",
-        "platform/definition",
+        "examples/platform",
       ],
       "envFile": "${workspaceFolder}/.env",
       "cwd": "${workspaceFolder}",

--- a/src/cli/cmd/harvest/modules/cmd.go
+++ b/src/cli/cmd/harvest/modules/cmd.go
@@ -95,7 +95,7 @@ func loadFrom(g db.DB, dir string) error {
 	schemaFilePath := path.Clean(path.Join(dir, constants.ModuleSchemaFilePath))
 	configs, _, err := tfconfig.LoadModulesFromResolvedSchema(schemaFilePath, filters...)
 	if err != nil {
-		panic(err)
+		return eris.Wrapf(err, "error loading module")
 	}
 
 	log.Info("Loaded modules", "count", len(configs))

--- a/src/cli/cmd/platform/lint/cmd.go
+++ b/src/cli/cmd/platform/lint/cmd.go
@@ -1,6 +1,11 @@
 package lint
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	flagDir string
@@ -22,11 +27,21 @@ func GetCmd() *cobra.Command {
 }
 
 func cmdRunE(cmd *cobra.Command, args []string) error {
+	if err := checkDirExists(flagDir); err != nil {
+		return err
+	}
 	err := lintPlatform(flagDir)
 	if err != nil {
 		return err
 	}
 
 	cmd.Printf("Platform parse and lint completed\n")
+	return nil
+}
+
+func checkDirExists(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("could not open given directory '%s': %w", dir, err)
+	}
 	return nil
 }


### PR DESCRIPTION
Check target directory for existence when running
lint command. Also fix panic caused by non-existing path in other CLI command.