### PR TITLE
TER-157 Parse Doc comments from platform Terraform

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "modules list",
+      "name": "Modules List",
       "type": "go",
       "request": "launch",
       "mode": "auto",
@@ -103,6 +103,26 @@
         "dependencies",
         "-d",
         "examples/farm/dependencies/"
+      ],
+      "envFile": "${workspaceFolder}/.env",
+      "cwd": "${workspaceFolder}",
+    },
+    {
+      "name": "Generate Terraform",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/src/cli/terrarium/main.go",
+      "args": [
+        "generate",
+        "-p",
+        "examples/platform",
+        "-a",
+        "examples/apps/voting-be",
+        "-a",
+        "examples/apps/voting-worker",
+        "-o",
+        "/tmp/.terrarium"
       ],
       "envFile": "${workspaceFolder}/.env",
       "cwd": "${workspaceFolder}",

--- a/examples/platform/terrarium.yaml
+++ b/examples/platform/terrarium.yaml
@@ -22,9 +22,13 @@ components:
         type: object
         properties:
             db_name:
+                title: Database Name
+                description: The name provided here may get prefix and suffix based
                 type: string
                 default: default_db
             version:
+                title: Version
+                description: Version of the PostgreSQL engine to use
                 type: string
                 default: "11"
       outputs:
@@ -52,6 +56,8 @@ components:
         type: object
         properties:
             version:
+                title: Version
+                description: Version of the Redis engine to use
                 type: string
                 default: 5.0.6
       outputs:

--- a/examples/platform/tr_gen_locals.tf
+++ b/examples/platform/tr_gen_locals.tf
@@ -1,4 +1,8 @@
 locals {
+
+  # Inputs for 'postgres' component instances.
+  # version: Version of the PostgreSQL engine to use
+  # db_name[Database Name]: The name provided here may get prefix and suffix based
   tr_component_postgres = {
     "default" : {
       "version" : "11",
@@ -6,9 +10,11 @@ locals {
     }
   }
 
+  # Inputs for 'redis' component instances.
+  # version: Version of the Redis engine to use
   tr_component_redis = {
-    "default": {
-      "version": "5.0.6"
+    "default" : {
+      "version" : "5.0.6"
     }
   }
 }

--- a/src/pkg/go.mod
+++ b/src/pkg/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/hashicorp/hcl/v2 v2.17.0
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
+	github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rotisserie/eris v0.5.4
 	github.com/sirupsen/logrus v1.9.3
@@ -72,7 +73,7 @@ require (
 	golang.org/x/crypto v0.10.0 // indirect
 	golang.org/x/net v0.11.0 // indirect
 	golang.org/x/sys v0.9.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	golang.org/x/text v0.12.0
 	google.golang.org/genproto v0.0.0-20230629202037-9506855d4529 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230629202037-9506855d4529 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/src/pkg/go.sum
+++ b/src/pkg/go.sum
@@ -163,6 +163,10 @@ github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs
 github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70 h1:xrd41BUTgqxyYFfFwGdt/bnwS8KNYzPraj8WgvJ5NWk=
+github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70/go.mod h1:GYeBD1CF7AqnKZK+UCytLcY3G+UKo0ByXX/3xfdNyqQ=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6 h1:8UsGZ2rr2ksmEru6lToqnXgA8Mz1DP11X4zSJ159C3k=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/src/pkg/metadata/platform/components.go
+++ b/src/pkg/metadata/platform/components.go
@@ -1,13 +1,25 @@
 package platform
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	"github.com/cldcvr/terrarium/src/pkg/jsonschema"
+	"github.com/icza/backscanner"
 	"github.com/xeipuuv/gojsonschema"
 	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var (
+	docCommentMatcher    = regexp.MustCompile("^\\s*#.+$")
+	docCommentArgMatcher = regexp.MustCompile("#\\s*(.+?)(\\s*\\[(.+)\\])?:\\s*(.+)")
 )
 
 func NewComponents(platformModule *tfconfig.Module) Components {
@@ -64,10 +76,63 @@ func (c *Component) fetchInputs(m *tfconfig.Module) {
 		c.Inputs = &jsonschema.Node{}
 	}
 
+	fieldDoc, _, err := parseBlockDocComment(m, v.Pos)
+	if err != nil {
+		return
+	}
+
 	cv, _ := v.Expression.Value(nil)
 	valMap := cv.AsValueMap()
-	if v, ok := valMap["default"]; ok {
-		extractSchema(c.Inputs, v)
+	if mv, ok := valMap["default"]; ok {
+		extractSchema(c.Inputs, mv, "", fieldDoc)
+	}
+}
+
+func parseBlockDocComment(m *tfconfig.Module, blockPos tfconfig.SourcePos) (args map[string][2]string, lines []string, err error) {
+	if blockPos.Filename == "" {
+		return
+	}
+	lines, err = readCommentLinesAbove(blockPos.Filename, blockPos.StartByte)
+	if err != nil {
+		return
+	}
+
+	args = make(map[string][2]string, len(lines))
+	for _, line := range lines {
+		if groups := docCommentArgMatcher.FindStringSubmatch(line); groups != nil {
+			args[groups[1]] = [2]string{groups[3], groups[4]}
+		}
+	}
+	return
+}
+
+// read all comment lines (ignoring empty lines) above a given end byte until the first non-comment or the end of file
+func readCommentLinesAbove(filename string, endPos int) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := backscanner.New(file, endPos)
+	for {
+		line, _, err := scanner.Line()
+		if err == io.EOF {
+			return lines, nil
+		} else if err != nil {
+			return lines, err
+		}
+
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" {
+			continue
+		} else if docCommentMatcher.MatchString(trimmedLine) {
+			lines = append(lines, trimmedLine)
+			continue
+		}
+
+		return lines, nil
 	}
 }
 
@@ -97,7 +162,16 @@ func (c *Component) fetchOutputs(m *tfconfig.Module) {
 	}
 }
 
-func extractSchema(existingSchema *jsonschema.Node, value cty.Value) {
+func extractSchema(existingSchema *jsonschema.Node, value cty.Value, fieldName string, fieldDoc map[string][2]string) {
+	if docString, ok := fieldDoc[fieldName]; ok {
+		title := docString[0]
+		if title == "" {
+			title = cases.Title(language.Und, cases.NoLower).String(fieldName) // use the field name in title format instead
+		}
+		existingSchema.Title = title
+		existingSchema.Description = docString[1]
+	}
+
 	switch value.Type().FriendlyName() {
 	case "object":
 		mapValue := value.AsValueMap()
@@ -109,7 +183,8 @@ func extractSchema(existingSchema *jsonschema.Node, value cty.Value) {
 
 		for key, val := range mapValue {
 			existingSchema.Properties[key] = &jsonschema.Node{}
-			extractSchema(existingSchema.Properties[key], val)
+			valueFieldName := strings.TrimPrefix(fmt.Sprintf("%s.%s", fieldName, key), ".")
+			extractSchema(existingSchema.Properties[key], val, valueFieldName, fieldDoc)
 		}
 	case "string":
 		existingSchema.Type = gojsonschema.TYPE_STRING
@@ -131,7 +206,7 @@ func extractSchema(existingSchema *jsonschema.Node, value cty.Value) {
 		}
 
 		if len(listVal) > 0 {
-			extractSchema(existingSchema.Items, listVal[0])
+			extractSchema(existingSchema.Items, listVal[0], fieldName, fieldDoc)
 		}
 	}
 }

--- a/src/pkg/metadata/platform/test-data.yaml
+++ b/src/pkg/metadata/platform/test-data.yaml
@@ -1,99 +1,105 @@
 components:
-    - id: postgres
-      inputs:
-        type: object
-        properties:
-            db_name:
-                type: string
-                default: default_db
-            version:
-                type: string
-                default: "11"
-      outputs:
-        type: object
-        properties:
-            host: {}
-            port: {}
-    - id: redis
-      inputs:
-        type: object
-        properties:
-            version:
-                type: string
-                default: 5.0.6
-      outputs:
-        type: object
-        properties:
-            host:
-                description: The address of the endpoint for the Redis replication group (cluster mode disabled)
-            port:
-                description: The port for the Redis replication group (cluster mode disabled)
+  - id: postgres
+    inputs:
+      type: object
+      properties:
+        db_name:
+          title: Database Name
+          description: The name provided here may get prefix and suffix based
+          type: string
+          default: default_db
+        version:
+          title: Version
+          description: Version of the PostgreSQL engine to use
+          type: string
+          default: "11"
+    outputs:
+      type: object
+      properties:
+        host: {}
+        port: {}
+  - id: redis
+    inputs:
+      type: object
+      properties:
+        version:
+          title: Version
+          description: Version of the Redis engine to use
+          type: string
+          default: 5.0.6
+    outputs:
+      type: object
+      properties:
+        host:
+          description: The address of the endpoint for the Redis replication group (cluster mode disabled)
+        port:
+          description: The port for the Redis replication group (cluster mode disabled)
 graph:
-    - id: data.aws_availability_zones.available
-      requirements:
-        - provider.aws
-    - id: local.azs
-      requirements: []
-    - id: local.database_enabled
-      requirements:
-        - local.tr_component_postgres
-    - id: local.elasticache_enabled
-      requirements:
-        - local.tr_component_redis
-    - id: local.tr_component_postgres
-      requirements: []
-    - id: local.tr_component_redis
-      requirements: []
-    - id: module.core_vpc
-      requirements:
-        - local.azs
-        - local.database_enabled
-        - local.elasticache_enabled
-        - resource.random_string.random
-    - id: module.postgres_security_group
-      requirements:
-        - module.core_vpc
-    - id: module.this
-      requirements: []
-    - id: module.tr_component_postgres
-      requirements:
-        - local.tr_component_postgres
-        - module.core_vpc
-        - module.postgres_security_group
-        - var.all_db_instance_class
-        - var.db_instance_class
-    - id: module.tr_component_redis
-      requirements:
-        - local.azs
-        - local.tr_component_redis
-        - module.core_vpc
-        - module.this
-    - id: output.data_az
-      requirements:
-        - data.aws_availability_zones.available
-    - id: output.tr_component_postgres_host
-      requirements:
-        - module.tr_component_postgres
-    - id: output.tr_component_postgres_port
-      requirements:
-        - module.tr_component_postgres
-    - id: output.tr_component_redis_host
-      requirements:
-        - module.tr_component_redis
-    - id: output.tr_component_redis_port
-      requirements:
-        - module.tr_component_redis
-    - id: output.vpc_id
-      requirements:
-        - module.core_vpc
-    - id: provider.aws
-      requirements: []
-    - id: provider.random
-      requirements: []
-    - id: resource.random_string.random
-      requirements:
-        - provider.random
-    - id: var.all_db_instance_class
-      requirements: []
-    - id: var.db_instance_class
-      requirements: []
+  - id: data.aws_availability_zones.available
+    requirements:
+      - provider.aws
+  - id: local.azs
+    requirements: []
+  - id: local.database_enabled
+    requirements:
+      - local.tr_component_postgres
+  - id: local.elasticache_enabled
+    requirements:
+      - local.tr_component_redis
+  - id: local.tr_component_postgres
+    requirements: []
+  - id: local.tr_component_redis
+    requirements: []
+  - id: module.core_vpc
+    requirements:
+      - local.azs
+      - local.database_enabled
+      - local.elasticache_enabled
+      - resource.random_string.random
+  - id: module.postgres_security_group
+    requirements:
+      - module.core_vpc
+  - id: module.this
+    requirements: []
+  - id: module.tr_component_postgres
+    requirements:
+      - local.tr_component_postgres
+      - module.core_vpc
+      - module.postgres_security_group
+      - var.all_db_instance_class
+      - var.db_instance_class
+  - id: module.tr_component_redis
+    requirements:
+      - local.azs
+      - local.tr_component_redis
+      - module.core_vpc
+      - module.this
+  - id: output.data_az
+    requirements:
+      - data.aws_availability_zones.available
+  - id: output.tr_component_postgres_host
+    requirements:
+      - module.tr_component_postgres
+  - id: output.tr_component_postgres_port
+    requirements:
+      - module.tr_component_postgres
+  - id: output.tr_component_redis_host
+    requirements:
+      - module.tr_component_redis
+  - id: output.tr_component_redis_port
+    requirements:
+      - module.tr_component_redis
+  - id: output.vpc_id
+    requirements:
+      - module.core_vpc
+  - id: provider.aws
+    requirements: []
+  - id: provider.random
+    requirements: []
+  - id: resource.random_string.random
+    requirements:
+      - provider.random
+  - id: var.all_db_instance_class
+    requirements: []
+  - id: var.db_instance_class
+    requirements: []


### PR DESCRIPTION
Extract the argument documentation from input definitions.

Read comment lines above each component tr_component_postgres local
and extract all lines that match argument documentation - i.e. <arg-name>: <arg-desc>

The field name will be used as title in the properties schema.
To override the title one can define an alternative string such as: # db_name[Database Name]: ...

```
locals {

  # Inputs for 'postgres' component instances.
  # version: Version of the PostgreSQL engine to use
  # db_name[Database Name]: The name provided here may get prefix and suffix based
  tr_component_postgres = {
    "default" : {
      "version" : "11",
      "db_name" : "default_db"
    }
  }

  # Inputs for 'redis' component instances.
  # version: Version of the Redis engine to use
  tr_component_redis = {
    "default" : {
      "version" : "5.0.6"
    }
  }
}
```