### PR TITLE
TER-218 Add release workflow for CLI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+on:
+  release:
+    types: [created]
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        exclude:
+          - goarch: arm64
+            goos: windows
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set env vars
+      run: |
+        {
+          echo "BUILD_DATE=$(date -u +%Y%m%d)"
+        } >> ${GITHUB_ENV}
+    - uses: wangyoucao577/go-release-action@v1.40
+      with:
+        github_token: ${{ secrets.GH_RELEASE_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: "1.20"
+        project_path: "./src/cli/terrarium"
+        binary_name: "terrarium"
+        ldflags: "-s -w -X 'github.com/cldcvr/terrarium/src/cli/internal/build.Version=${{ github.ref_name }}' -X 'github.com/cldcvr/terrarium/src/cli/internal/build.Date=${{ env.BUILD_DATE }}'"
+        overwrite: true

--- a/setup.md
+++ b/setup.md
@@ -42,8 +42,10 @@ CLI connects with PostgreSQL Database to store the persistent data.
       go install github.com/cldcvr/terrarium/src/cli/terrarium@latest
       ```
 
-    - Download pre-compiled binary from GitHub Release (coming soon)
+    - Download pre-compiled binary from GitHub Release
 
+      There are downloadable assets associated with each CLI release in Github. These can be downloaded directly from [the Terrarium Github release page](https://github.com/cldcvr/terrarium/releases)
+<tr/>
 2. Seed & Run Database
 
    ```sh


### PR DESCRIPTION
Added a Github action workflow that is triggered by the creation of
a release. It will build the various OS/Arch combinations of the CLI
and upload a separate .tar.gz/zip for each to the GH release assets.
