### PR TITLE
TER-224 add retry setting to viper config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN apk update && apk add make && rm -rf /var/cache/apk/*
 WORKDIR /app
 COPY --from=cli-build /go/bin/terrarium /bin/
 COPY Makefile ./
-ENV FARM_DIR=./farm
+ENV FARM_DIR=./farm \
+	TR_DB_RETRY_ATTEMPTS=20
 # workaround to use Makefile
 RUN mkdir -p ./src/pkg && \
 	mkdir -p ./src/cli

--- a/go.work.sum
+++ b/go.work.sum
@@ -355,7 +355,6 @@ github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.exclusions=**/vendor/**,internal/testing/**/*,**/mocks/**/*,**/*.pb.go,**/
 # test files and coverage
 sonar.test.inclusions=**/*_test.go
 
-sonar.coverage.exclusions=**/example.go,**/example/*,**/pkg/testutils/**,**/pkg/pb/**,**/mocks/**,**/*_mock.go,**/*_adapter.go,**/pkg/server/**,pkg/git/factory.go,**/cmd/main.go,**/cmocks/**
+sonar.coverage.exclusions=**/example.go,**/example/*,**/pkg/testutils/**,**/pkg/pb/**,**/mocks/**,**/*_mock.go,**/*_adapter.go,**/pkg/server/**,pkg/git/factory.go,**/cmd/main.go,**/cmocks/**,**/internal/config/**
 
 
 # duplication exclusions

--- a/src/api/internal/config/database.go
+++ b/src/api/internal/config/database.go
@@ -37,6 +37,21 @@ func DBSSLMode() bool {
 	return confighelper.MustGetBool("db.ssl_mode")
 }
 
+// DBRetryAttempts returns the max number of re-ties on DB connection request failure
+func DBRetryAttempts() int {
+	return confighelper.MustGetInt("db.retry_attempts")
+}
+
+// DBRetryInterval returns interval to wait for before retrying. (in seconds)
+func DBRetryInterval() int {
+	return confighelper.MustGetInt("db.retry_interval_sec")
+}
+
+// DBRetryInterval returns additional random time (in seconds) between 0 and this, to be added to the wait time.
+func DBRetryJitter() int {
+	return confighelper.MustGetInt("db.retry_jitter_sec")
+}
+
 // DBConnect establishes a connection to the database using the connection parameters from the environment.
 func DBConnect() (db.DB, error) {
 	g, err := dbhelper.ConnectPG(
@@ -46,7 +61,7 @@ func DBConnect() (db.DB, error) {
 		DBName(),
 		DBPort(),
 		DBSSLMode(),
-		dbhelper.WithRetries(20, 3, 3),
+		dbhelper.WithRetries(DBRetryAttempts(), DBRetryInterval(), DBRetryJitter()),
 	)
 	if err != nil {
 		return nil, eris.Wrap(err, "could not establish a connection to the database")

--- a/src/api/internal/config/defaults.yaml
+++ b/src/api/internal/config/defaults.yaml
@@ -14,18 +14,22 @@
 # The following is the default configuration:
 
 db:
-  host: "localhost"
-  user: "postgres"
-  # password: # no default, panic if not set.
-  name: "cc_terrarium"
-  port: 5432
-  ssl_mode: false
-  type: postgres
+  host: "localhost"      # db host name
+  user: "postgres"       # db username
+  # password:            # db password no default, panic if not set.
+  name: "cc_terrarium"   # database name
+  port: 5432             # db port
+  ssl_mode: false        # enable SSL mode
+  type: postgres         # type of db - postgres | sqlite
+  dsn: embedded.db       # SQLite Data Source Name
+  retry_attempts: 20     # max number of re-tries on connection request failure
+  retry_interval_sec: 2  # time to wait for (in seconds) before each retry
+  retry_jitter_sec: 2    # additional random time (in seconds) between 0 and this, to be added to the wait time
 
 log:
-  format: "JSON"
-  level: "info"
-  pretty_print: false
+  format: "JSON"        # log format - text | json
+  level: "info"         # maximum log level - debug | info | warn | error | fatal
+  pretty_print: false   # format the text log using colors and indentation etc.
 
 server:
   http_port: 3000

--- a/src/cli/internal/config/database.go
+++ b/src/cli/internal/config/database.go
@@ -51,6 +51,21 @@ func DBDSN() string {
 	return confighelper.MustGetString("db.dsn")
 }
 
+// DBRetryAttempts returns the max number of re-ties on DB connection request failure
+func DBRetryAttempts() int {
+	return confighelper.MustGetInt("db.retry_attempts")
+}
+
+// DBRetryInterval returns interval to wait for before retrying. (in seconds)
+func DBRetryInterval() int {
+	return confighelper.MustGetInt("db.retry_interval_sec")
+}
+
+// DBRetryInterval returns additional random time (in seconds) between 0 and this, to be added to the wait time.
+func DBRetryJitter() int {
+	return confighelper.MustGetInt("db.retry_jitter_sec")
+}
+
 // DBConnect establishes a connection to the database using the connection parameters from the environment.
 func DBConnect() (db.DB, error) {
 	var g *gorm.DB
@@ -71,6 +86,7 @@ func DBConnect() (db.DB, error) {
 			DBName(),
 			DBPort(),
 			DBSSLMode(),
+			dbhelper.WithRetries(DBRetryAttempts(), DBRetryInterval(), DBRetryJitter()),
 		)
 		if err != nil {
 			return nil, eris.Wrap(err, "could not establish a connection to the database")

--- a/src/cli/internal/config/defaults.yaml
+++ b/src/cli/internal/config/defaults.yaml
@@ -14,18 +14,21 @@
 # The following is the default configuration:
 
 db:
-  host: "localhost"
-  user: "postgres"
-  # password: # no default, panic if not set.
-  name: "cc_terrarium"
-  port: 5432
-  ssl_mode: false
-  type: postgres
-  dsn: embedded.db
+  host: "localhost"      # db host name
+  user: "postgres"       # db username
+  # password:            # db password no default, panic if not set.
+  name: "cc_terrarium"   # database name
+  port: 5432             # db port
+  ssl_mode: false        # enable SSL mode
+  type: postgres         # type of db - postgres | sqlite
+  dsn: embedded.db       # SQLite Data Source Name
+  retry_attempts: 0      # max number of re-tries on connection request failure
+  retry_interval_sec: 3  # time to wait for (in seconds) before each retry
+  retry_jitter_sec: 0    # additional random time (in seconds) between 0 and this, to be added to the wait time
 
 log:
-  format: "text"
-  level: "info" # debug | info | warn | error | fatal
+  format: "text"        # log format - text | json
+  level: "info"         # maximum log level - debug | info | warn | error | fatal
 
 terraform:
   plugin_cache_dir: "~/.terraform.d/plugin-cache"

--- a/src/pkg/db/dbhelper/options.go
+++ b/src/pkg/db/dbhelper/options.go
@@ -26,6 +26,14 @@ func getDefaultConfig() connConfig {
 
 type ConnOption func(*connConfig)
 
+// WithRetries configures db connection retries.
+// maxRetries represents number of times the connection request should be retried on failure.
+// one attempt is done regardless. and then re-attempt is done based on this number. i.e. <1
+// means total 1 attempt. >1 means n+1 attempt in total.
+// retryIntervalSec represents wait time (in seconds) before each retry attempt.
+// jitterLimitSec represents jitter time limit (in seconds), such that a random time
+// interval between 0 and this number is selected and added to the retry interval on each retry
+// attempt to avoid high retry traffic on exact same time from all servers.
 func WithRetries(maxRetries, retryIntervalSec, jitterLimitSec int) ConnOption {
 	return func(cc *connConfig) {
 		cc.maxRetries = maxRetries
@@ -34,6 +42,11 @@ func WithRetries(maxRetries, retryIntervalSec, jitterLimitSec int) ConnOption {
 	}
 }
 
+// WithLogger configures the logger instance used by the database manager.
+// writer instance allows setting up the log destination. By default, we set it to
+// standard `log.Default()`.
+// config is the gorm logger config that allows setting the log level, etc.
+// by default, we set log level to Warning.
 func WithLogger(writer logger.Writer, config logger.Config) ConnOption {
 	return func(cc *connConfig) {
 		cc.logger = logger.New(writer, config)


### PR DESCRIPTION
This change is intended to fix checks failure in: https://github.com/cldcvr/terrarium-farm/pull/9

The above failure is caused by long waiting time in db restore process. hence to fix it, we add a configurable retry system to cli, and in crease the default retries to 20 in the farm-harvester image.