### PR TITLE
TER-227 Implement components annotation comments

### DIFF
--- a/examples/platform/component_postgres.tf
+++ b/examples/platform/component_postgres.tf
@@ -1,3 +1,4 @@
+# component[PostgreSQL Database]: A relational database management system using SQL.
 module "tr_component_postgres" {
   source = "terraform-aws-modules/rds/aws"
 

--- a/examples/platform/component_redis.tf
+++ b/examples/platform/component_redis.tf
@@ -1,3 +1,4 @@
+# component[Redis Cache]: An in-memory data structure store used as a cache or message broker.
 module "tr_component_redis" {
   source = "cloudposse/elasticache-redis/aws"
 
@@ -15,10 +16,10 @@ module "tr_component_redis" {
 }
 
 module "this" {
-  source  = "cloudposse/label/null"
+  source = "cloudposse/label/null"
   # Cloud Posse recommends pinning every module to a specific version
   # version = "x.x.x"
-  namespace  = "var.namespace"
-  stage      = "var.stage"
-  name       = "var.name"
+  namespace = "var.namespace"
+  stage     = "var.stage"
+  name      = "var.name"
 }

--- a/examples/platform/outputs.tf
+++ b/examples/platform/outputs.tf
@@ -1,21 +1,23 @@
 ## Postgres component outputs
 
 output "tr_component_postgres_host" {
-  value = { for k, v in module.tr_component_postgres : k => v.db_instance_address }
+  description = "The host address of the PostgreSQL server."
+  value       = { for k, v in module.tr_component_postgres : k => v.db_instance_address }
 }
 
 output "tr_component_postgres_port" {
-  value = { for k, v in module.tr_component_postgres : k => v.db_instance_port }
+  description = "The port number on which the PostgreSQL server is listening."
+  value       = { for k, v in module.tr_component_postgres : k => v.db_instance_port }
 }
 
 output "tr_component_redis_host" {
   description = "The address of the endpoint for the Redis replication group (cluster mode disabled)"
-  value = { for k, v in module.tr_component_redis : k => v.endpoint }
+  value       = { for k, v in module.tr_component_redis : k => v.endpoint }
 }
 
 output "tr_component_redis_port" {
   description = "The port for the Redis replication group (cluster mode disabled)"
-  value = { for k, v in module.tr_component_redis : k => v.port }
+  value       = { for k, v in module.tr_component_redis : k => v.port }
 }
 
 output "vpc_id" {

--- a/examples/platform/terrarium.yaml
+++ b/examples/platform/terrarium.yaml
@@ -64,11 +64,11 @@ components:
         properties:
             host:
                 title: Host
-                description: The host address of the Redis server.
+                description: The address of the endpoint for the Redis replication group (cluster mode disabled)
                 type: string
             port:
                 title: Port
-                description: The port number on which the Redis server is listening.
+                description: The port for the Redis replication group (cluster mode disabled)
                 type: string
     - id: server_private
       title: Private Service

--- a/src/cli/cmd/platform/lint/testdata/valid-terraform-1/terrarium.yaml
+++ b/src/cli/cmd/platform/lint/testdata/valid-terraform-1/terrarium.yaml
@@ -1,19 +1,24 @@
 components:
     - id: postgres
+      title: Postgres
       inputs:
         type: object
         properties:
             db_name:
+                title: Db Name
                 type: string
                 default: default_db
             version:
+                title: Version
                 type: string
                 default: "11.12"
       outputs:
         type: object
         properties:
-            host: {}
-            port: {}
+            host:
+                title: Host
+            port:
+                title: Port
 graph:
     - id: module.postgres_security_group
       requirements: []

--- a/src/pkg/metadata/platform/example.yaml
+++ b/src/pkg/metadata/platform/example.yaml
@@ -29,29 +29,29 @@ components:
           description: The password for accessing the PostgreSQL database.
 
 graph:
-    - id: output.vpc_id
-      requirements:
-        - module.core_vpc
-    - id: output.data_az
-      requirements:
-        - data.aws_availability_zones.available
-    - id: output.tr_component_postgres_host
-      requirements:
-        - module.tr_component_postgres
-    - id: output.tr_component_postgres_port
-      requirements:
-        - module.tr_component_postgres
-    - id: module.tr_component_postgres
-      requirements:
-        - module.postgres_security_group
-        - module.core_vpc
-    - id: module.postgres_security_group
-      requirements:
-        - module.core_vpc
-    - id: module.core_vpc
-      requirements:
-        - resource.random_string.random
-    - id: resource.random_string.random
-      requirements: []
-    - id: data.aws_availability_zones.available
-      requirements: []
+  - id: output.vpc_id
+    requirements:
+      - module.core_vpc
+  - id: output.data_az
+    requirements:
+      - data.aws_availability_zones.available
+  - id: output.tr_component_postgres_host
+    requirements:
+      - module.tr_component_postgres
+  - id: output.tr_component_postgres_port
+    requirements:
+      - module.tr_component_postgres
+  - id: module.tr_component_postgres
+    requirements:
+      - module.postgres_security_group
+      - module.core_vpc
+  - id: module.postgres_security_group
+    requirements:
+      - module.core_vpc
+  - id: module.core_vpc
+    requirements:
+      - resource.random_string.random
+  - id: resource.random_string.random
+    requirements: []
+  - id: data.aws_availability_zones.available
+    requirements: []

--- a/src/pkg/metadata/platform/model.go
+++ b/src/pkg/metadata/platform/model.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	ComponentPrefix = "tr_component_" // Prefix for component identifiers in terraform code
+	ComponentDocPrefix = "component"     // Documentation comment prefix (i.e. "component[<name-override>]: <description>")
+	ComponentPrefix    = "tr_component_" // Prefix for component identifiers in terraform code
 )
 
 // Component represents an implementation of a dependency in the Terrarium platform.

--- a/src/pkg/metadata/platform/test-data.yaml
+++ b/src/pkg/metadata/platform/test-data.yaml
@@ -1,5 +1,7 @@
 components:
   - id: postgres
+    title: PostgreSQL Database
+    description: A relational database management system using SQL.
     inputs:
       type: object
       properties:
@@ -16,9 +18,15 @@ components:
     outputs:
       type: object
       properties:
-        host: {}
-        port: {}
+        host:
+          title: Host
+          description: The host address of the PostgreSQL server.
+        port:
+          title: Port
+          description: The port number on which the PostgreSQL server is listening.
   - id: redis
+    title: Redis Cache
+    description: An in-memory data structure store used as a cache or message broker.
     inputs:
       type: object
       properties:
@@ -31,8 +39,10 @@ components:
       type: object
       properties:
         host:
+          title: Host
           description: The address of the endpoint for the Redis replication group (cluster mode disabled)
         port:
+          title: Port
           description: The port for the Redis replication group (cluster mode disabled)
 graph:
   - id: data.aws_availability_zones.available


### PR DESCRIPTION
Add annotation comments to components.
Component annotation is similar to input annotation. It must begin with keyword "component" and allows for optional name override. Otherwise the name is derived from module call ID.

```
component[Redis Cache]: description string
```

Also:

Compute title string from output names.
Always keep documentation (title and description)
in-sync with Terraform code.