### PR TITLE
VAN-237 Add copyright headers

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,23 @@
+schema_version = 1
+
+project {
+  license        = "Apache-2.0"
+  copyright_year = 2023
+  copyright_holder = "CloudCover"
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    "**.md",
+    "**/*.tf",
+    "**/*.tfvars",
+    "**/testdata/**",
+    "**/*.pb.go",
+    "**/mocks", 
+    "**/.terraform",
+    ".git",
+    "coverage",
+    ".bin",
+  ]
+}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -83,3 +83,15 @@ jobs:
           path: coverage
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+  check-headers:
+    name: Check Copyright Headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Copywrite
+        uses: hashicorp/setup-copywrite@v1.1.2
+
+      - name: Check Header Compliance
+        run: copywrite headers --plan

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,2 +1,5 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 quiet: True
 disable-version-string: True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,14 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 repos:
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.12.0
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: copywrite-headers
+        name: copywrite-headers
+        entry: copywrite headers
+        language: system

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 ARG TERRAFORM_VERSION=1.5
 
 FROM golang:1.20 AS go-base

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2023 CloudCover
+
 
                                  Apache License
                            Version 2.0, January 2004

--- a/Makefile
+++ b/Makefile
@@ -214,3 +214,4 @@ help:
 
 -include scripts/mocks.mak
 -include scripts/protoc.mak
+-include scripts/copyright.mak

--- a/build/terrarium-api-test-run-pr.yml
+++ b/build/terrarium-api-test-run-pr.yml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 name: $(Build.DefinitionName)_${{ replace(replace(variables['Build.SourceBranch'],'refs/heads/',''),'/','_') }}_$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger: none

--- a/data/init.sh
+++ b/data/init.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 
 # Specify the path to the database dump file
 dump_file="/docker-entrypoint-initdb.d/cc_terrarium.psql"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 version: '3'
 
 networks:

--- a/examples/apps/voting-be/terrarium.yaml
+++ b/examples/apps/voting-be/terrarium.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 id: voting_be
 name: Voting Backend
 env_prefix: VO

--- a/examples/apps/voting-fe/terrarium.yaml
+++ b/examples/apps/voting-fe/terrarium.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 id: voting_fe
 name: Voting Frontend
 env_prefix: VO

--- a/examples/apps/voting-worker/terrarium.yaml
+++ b/examples/apps/voting-worker/terrarium.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 id: voting_worker
 name: Voting Worker
 env_prefix: VO

--- a/examples/farm/dependencies/compute.yaml
+++ b/examples/farm/dependencies/compute.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 dependency-interfaces:
   - id: server_web
     # taxonomy: compute/server/web

--- a/examples/farm/dependencies/storage.yaml
+++ b/examples/farm/dependencies/storage.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 dependency-interfaces:
   - id: postgres
     # taxonomy: storage/database/rdbms/postgres

--- a/examples/farm/modules.yaml
+++ b/examples/farm/modules.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 farm:
   - name: eks
     source: "terraform-aws-modules/eks/aws"

--- a/examples/platform/terrarium.yaml
+++ b/examples/platform/terrarium.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 components:
     - id: job_queue
       title: Background Service

--- a/scripts/copyright.mak
+++ b/scripts/copyright.mak
@@ -1,0 +1,4 @@
+.PHONY: headers
+
+headers:
+	copywrite headers

--- a/src/api/internal/config/database.go
+++ b/src/api/internal/config/database.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/src/api/internal/config/defaults.yaml
+++ b/src/api/internal/config/defaults.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 # Configuration System:
 #
 # The project uses the Viper library to manage its configuration system.

--- a/src/api/internal/config/farm.go
+++ b/src/api/internal/config/farm.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import "github.com/cldcvr/terrarium/src/pkg/confighelper"

--- a/src/api/internal/config/init.go
+++ b/src/api/internal/config/init.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/src/api/internal/config/logging.go
+++ b/src/api/internal/config/logging.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/src/api/internal/config/server.go
+++ b/src/api/internal/config/server.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import "github.com/cldcvr/terrarium/src/pkg/confighelper"

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/src/api/service/service.go
+++ b/src/api/service/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package service
 
 import (

--- a/src/api/service/terrariumsrv/code_completion.go
+++ b/src/api/service/terrariumsrv/code_completion.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 // DEPRECATED

--- a/src/api/service/terrariumsrv/code_completion_test.go
+++ b/src/api/service/terrariumsrv/code_completion_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import (

--- a/src/api/service/terrariumsrv/helpers_test.go
+++ b/src/api/service/terrariumsrv/helpers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import (

--- a/src/api/service/terrariumsrv/module_attr_query.go
+++ b/src/api/service/terrariumsrv/module_attr_query.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import (

--- a/src/api/service/terrariumsrv/module_query.go
+++ b/src/api/service/terrariumsrv/module_query.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import (

--- a/src/api/service/terrariumsrv/module_query_test.go
+++ b/src/api/service/terrariumsrv/module_query_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import (

--- a/src/api/service/terrariumsrv/service.go
+++ b/src/api/service/terrariumsrv/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import (

--- a/src/api/service/terrariumsrv/utils.go
+++ b/src/api/service/terrariumsrv/utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import "github.com/cldcvr/terrarium/src/pkg/pb/terrariumpb"

--- a/src/api/service/terrariumsrv/utils_test.go
+++ b/src/api/service/terrariumsrv/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package terrariumsrv
 
 import (

--- a/src/api/transport/transport.go
+++ b/src/api/transport/transport.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package transport
 
 import (

--- a/src/cli/cmd/generate/apps.go
+++ b/src/cli/cmd/generate/apps.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package generate
 
 import (

--- a/src/cli/cmd/generate/cmd.go
+++ b/src/cli/cmd/generate/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package generate
 
 import (

--- a/src/cli/cmd/generate/cmd_test.go
+++ b/src/cli/cmd/generate/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package generate
 
 import (

--- a/src/cli/cmd/generate/generate.go
+++ b/src/cli/cmd/generate/generate.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package generate
 
 import (

--- a/src/cli/cmd/harvest/cmd.go
+++ b/src/cli/cmd/harvest/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package harvest
 
 import (

--- a/src/cli/cmd/harvest/cmd_test.go
+++ b/src/cli/cmd/harvest/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package harvest
 
 import (

--- a/src/cli/cmd/harvest/dependencies/cmd.go
+++ b/src/cli/cmd/harvest/dependencies/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dependencies
 
 import (

--- a/src/cli/cmd/harvest/dependencies/cmd_test.go
+++ b/src/cli/cmd/harvest/dependencies/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/cli/cmd/harvest/dependencies/dependencies.go
+++ b/src/cli/cmd/harvest/dependencies/dependencies.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dependencies
 
 import (

--- a/src/cli/cmd/harvest/dependencies/dependencies_test.go
+++ b/src/cli/cmd/harvest/dependencies/dependencies_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dependencies
 
 import (

--- a/src/cli/cmd/harvest/mappings/cmd.go
+++ b/src/cli/cmd/harvest/mappings/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package mappings
 
 import (

--- a/src/cli/cmd/harvest/mappings/cmd_test.go
+++ b/src/cli/cmd/harvest/mappings/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/cli/cmd/harvest/mappings/mappings.go
+++ b/src/cli/cmd/harvest/mappings/mappings.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package mappings
 
 import (

--- a/src/cli/cmd/harvest/mappings/mappings_test.go
+++ b/src/cli/cmd/harvest/mappings/mappings_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package mappings
 
 import (

--- a/src/cli/cmd/harvest/modules/cmd.go
+++ b/src/cli/cmd/harvest/modules/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/src/cli/cmd/harvest/modules/cmd_test.go
+++ b/src/cli/cmd/harvest/modules/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/cli/cmd/harvest/modules/modules.go
+++ b/src/cli/cmd/harvest/modules/modules.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/src/cli/cmd/harvest/modules/modules_test.go
+++ b/src/cli/cmd/harvest/modules/modules_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/src/cli/cmd/harvest/resources/cmd.go
+++ b/src/cli/cmd/harvest/resources/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package resources
 
 import (

--- a/src/cli/cmd/harvest/resources/cmd_test.go
+++ b/src/cli/cmd/harvest/resources/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/cli/cmd/harvest/resources/resources.go
+++ b/src/cli/cmd/harvest/resources/resources.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package resources
 
 import (

--- a/src/cli/cmd/harvest/resources/resources_test.go
+++ b/src/cli/cmd/harvest/resources/resources_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package resources
 
 import (

--- a/src/cli/cmd/platform/cmd.go
+++ b/src/cli/cmd/platform/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/cli/cmd/platform/cmd_test.go
+++ b/src/cli/cmd/platform/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/cli/cmd/platform/lint/cmd.go
+++ b/src/cli/cmd/platform/lint/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package lint
 
 import (

--- a/src/cli/cmd/platform/lint/cmd_test.go
+++ b/src/cli/cmd/platform/lint/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package lint
 
 import (

--- a/src/cli/cmd/platform/lint/lint.go
+++ b/src/cli/cmd/platform/lint/lint.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package lint
 
 import (

--- a/src/cli/cmd/platform/lint/lint_test.go
+++ b/src/cli/cmd/platform/lint/lint_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package lint
 
 import (

--- a/src/cli/cmd/query/cmd.go
+++ b/src/cli/cmd/query/cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package query
 
 import (

--- a/src/cli/cmd/query/cmd_test.go
+++ b/src/cli/cmd/query/cmd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package query
 
 import (

--- a/src/cli/cmd/query/modules/modules.go
+++ b/src/cli/cmd/query/modules/modules.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/src/cli/cmd/query/modules/modules_test.go
+++ b/src/cli/cmd/query/modules/modules_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/cli/cmd/root.go
+++ b/src/cli/cmd/root.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/src/cli/cmd/root_test.go
+++ b/src/cli/cmd/root_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/src/cli/cmd/version/version.go
+++ b/src/cli/cmd/version/version.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (

--- a/src/cli/cmd/version/version_test.go
+++ b/src/cli/cmd/version/version_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (

--- a/src/cli/internal/build/build.go
+++ b/src/cli/internal/build/build.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package build
 
 // Version is dynamically set by the toolchain or overridden by the Makefile.

--- a/src/cli/internal/config/database.go
+++ b/src/cli/internal/config/database.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/src/cli/internal/config/database_mock.go
+++ b/src/cli/internal/config/database_mock.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/cli/internal/config/defaults.yaml
+++ b/src/cli/internal/config/defaults.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 # Configuration System:
 #
 # The project uses the Viper library to manage its configuration system.

--- a/src/cli/internal/config/farm.go
+++ b/src/cli/internal/config/farm.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import "github.com/cldcvr/terrarium/src/pkg/confighelper"

--- a/src/cli/internal/config/init.go
+++ b/src/cli/internal/config/init.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/src/cli/internal/config/logging.go
+++ b/src/cli/internal/config/logging.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/src/cli/internal/constants/constants.go
+++ b/src/cli/internal/constants/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package constants
 
 import "io/fs"

--- a/src/cli/internal/utils/utils.go
+++ b/src/cli/internal/utils/utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/src/cli/terrarium/main.go
+++ b/src/cli/terrarium/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import "github.com/cldcvr/terrarium/src/cli/cmd"

--- a/src/pkg/commander/commander.go
+++ b/src/pkg/commander/commander.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package commander
 
 import "os/exec"

--- a/src/pkg/commander/factory.go
+++ b/src/pkg/commander/factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !mock
 // +build !mock
 

--- a/src/pkg/commander/iface.go
+++ b/src/pkg/commander/iface.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package commander
 
 import "os/exec"

--- a/src/pkg/commander/mock_factory.go
+++ b/src/pkg/commander/mock_factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/pkg/confighelper/config.go
+++ b/src/pkg/confighelper/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package confighelper
 
 import (

--- a/src/pkg/confighelper/config_test.go
+++ b/src/pkg/confighelper/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package confighelper
 
 import (

--- a/src/pkg/db/connection.go
+++ b/src/pkg/db/connection.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import (

--- a/src/pkg/db/connection_test.go
+++ b/src/pkg/db/connection_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build dbtest
 // +build dbtest
 

--- a/src/pkg/db/data_test.go
+++ b/src/pkg/db/data_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build dbtest
 // +build dbtest
 

--- a/src/pkg/db/dbhelper/connection.go
+++ b/src/pkg/db/dbhelper/connection.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dbhelper
 
 import (

--- a/src/pkg/db/dbhelper/connection_test.go
+++ b/src/pkg/db/dbhelper/connection_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dbhelper
 
 import (

--- a/src/pkg/db/dbhelper/options.go
+++ b/src/pkg/db/dbhelper/options.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dbhelper
 
 import (

--- a/src/pkg/db/dependency.go
+++ b/src/pkg/db/dependency.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import (

--- a/src/pkg/db/module.go
+++ b/src/pkg/db/module.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import (

--- a/src/pkg/db/module_attribute.go
+++ b/src/pkg/db/module_attribute.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import (

--- a/src/pkg/db/module_db_test.go
+++ b/src/pkg/db/module_db_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build dbtest
 // +build dbtest
 

--- a/src/pkg/db/module_test.go
+++ b/src/pkg/db/module_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import (

--- a/src/pkg/db/provider.go
+++ b/src/pkg/db/provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import (

--- a/src/pkg/db/res_attributes_mapping.go
+++ b/src/pkg/db/res_attributes_mapping.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import "github.com/google/uuid"

--- a/src/pkg/db/resource_attributes.go
+++ b/src/pkg/db/resource_attributes.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import "github.com/google/uuid"

--- a/src/pkg/db/resource_type.go
+++ b/src/pkg/db/resource_type.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import "github.com/google/uuid"

--- a/src/pkg/db/taxonomy.go
+++ b/src/pkg/db/taxonomy.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import "github.com/google/uuid"

--- a/src/pkg/db/utils.go
+++ b/src/pkg/db/utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package db
 
 import (

--- a/src/pkg/env/env.go
+++ b/src/pkg/env/env.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package env
 
 import (

--- a/src/pkg/env/env_test.go
+++ b/src/pkg/env/env_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package env
 
 import (

--- a/src/pkg/jsonschema/schema.go
+++ b/src/pkg/jsonschema/schema.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package jsonschema
 
 import (

--- a/src/pkg/jsonschema/schema_test.go
+++ b/src/pkg/jsonschema/schema_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package jsonschema
 
 import (

--- a/src/pkg/localstate/localstate.go
+++ b/src/pkg/localstate/localstate.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package localstate
 
 import (

--- a/src/pkg/localstate/localstate_test.go
+++ b/src/pkg/localstate/localstate_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package localstate
 
 import (

--- a/src/pkg/metadata/app/example.yaml
+++ b/src/pkg/metadata/app/example.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 id: banking_app # REQUIRED. no special chars, start with alpha, contains alpha-num, and cannot be gt 20 chars. used by IaC to uniquely identify the dependency in the project.
 name: Banking App
 env_prefix: BA # defaults to empty string.

--- a/src/pkg/metadata/app/model.go
+++ b/src/pkg/metadata/app/model.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import "gopkg.in/yaml.v3"

--- a/src/pkg/metadata/app/utils.go
+++ b/src/pkg/metadata/app/utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/src/pkg/metadata/app/utils_test.go
+++ b/src/pkg/metadata/app/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/src/pkg/metadata/cli/example.yaml
+++ b/src/pkg/metadata/cli/example.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 farm:
   - name: vpc # REQUIRED: unique user-defined module name (will be used as name for exported modules)
     source: "terraform-aws-modules/vpc/aws" # REQUIRED: Terraform module source

--- a/src/pkg/metadata/cli/model.go
+++ b/src/pkg/metadata/cli/model.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package cli
 
 import (

--- a/src/pkg/metadata/cli/model_test.go
+++ b/src/pkg/metadata/cli/model_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package cli
 
 import (

--- a/src/pkg/metadata/dependency/example.yaml
+++ b/src/pkg/metadata/dependency/example.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 dependency-interfaces: # file header
   - id: postgres # identifier for the dependency represented by a Taxon
     title: PostgreSQL Database # Display title of the dependency

--- a/src/pkg/metadata/dependency/model.go
+++ b/src/pkg/metadata/dependency/model.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dependency
 
 import (

--- a/src/pkg/metadata/dependency/model_test.go
+++ b/src/pkg/metadata/dependency/model_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package dependency
 
 import (

--- a/src/pkg/metadata/platform/blockid.go
+++ b/src/pkg/metadata/platform/blockid.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/blockid_test.go
+++ b/src/pkg/metadata/platform/blockid_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/components.go
+++ b/src/pkg/metadata/platform/components.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/components_test.go
+++ b/src/pkg/metadata/platform/components_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/example.yaml
+++ b/src/pkg/metadata/platform/example.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 components:
   - id: postgres
     implements: postgres

--- a/src/pkg/metadata/platform/graph.go
+++ b/src/pkg/metadata/platform/graph.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/graph_test.go
+++ b/src/pkg/metadata/platform/graph_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/model.go
+++ b/src/pkg/metadata/platform/model.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/parse_test.go
+++ b/src/pkg/metadata/platform/parse_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package platform
 
 import (

--- a/src/pkg/metadata/platform/test-data.yaml
+++ b/src/pkg/metadata/platform/test-data.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
 components:
   - id: postgres
     title: PostgreSQL Database

--- a/src/pkg/metadata/taxonomy/model.go
+++ b/src/pkg/metadata/taxonomy/model.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package taxonomy
 
 import "strings"

--- a/src/pkg/metadata/taxonomy/model_test.go
+++ b/src/pkg/metadata/taxonomy/model_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package taxonomy
 
 import (

--- a/src/pkg/pb/terrariumpb/service.proto
+++ b/src/pkg/pb/terrariumpb/service.proto
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 //go:generate mockery --name TerrariumServiceServer

--- a/src/pkg/testutils/clitesting/cli_test_framework.go
+++ b/src/pkg/testutils/clitesting/cli_test_framework.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package clitesting
 
 import (

--- a/src/pkg/testutils/mock_cmd.go
+++ b/src/pkg/testutils/mock_cmd.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package testutils
 
 import (

--- a/src/pkg/testutils/testcommon.go
+++ b/src/pkg/testutils/testcommon.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package testutils
 
 import (

--- a/src/pkg/testutils/token.go
+++ b/src/pkg/testutils/token.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package testutils
 
 import (

--- a/src/pkg/testutils/token_test.go
+++ b/src/pkg/testutils/token_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package testutils
 
 import (

--- a/src/pkg/testutils/validation.go
+++ b/src/pkg/testutils/validation.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package testutils
 
 import (

--- a/src/pkg/testutils/validation_test.go
+++ b/src/pkg/testutils/validation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package testutils
 
 import (

--- a/src/pkg/tf/parser/expressions.go
+++ b/src/pkg/tf/parser/expressions.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package parser
 
 import (

--- a/src/pkg/tf/parser/expressions_test.go
+++ b/src/pkg/tf/parser/expressions_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package parser
 
 import (

--- a/src/pkg/tf/runner/run.go
+++ b/src/pkg/tf/runner/run.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/src/pkg/tf/runner/run_test.go
+++ b/src/pkg/tf/runner/run_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/pkg/tf/runner/utils.go
+++ b/src/pkg/tf/runner/utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 func TerraformProviderSchema(runner *terraformRunner, dir string, outFilePath string) error {

--- a/src/pkg/tf/runner/utils_test.go
+++ b/src/pkg/tf/runner/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build mock
 // +build mock
 

--- a/src/pkg/tf/schema/provider.go
+++ b/src/pkg/tf/schema/provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 import "fmt"

--- a/src/pkg/tf/schema/provider_test.go
+++ b/src/pkg/tf/schema/provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 import (

--- a/src/pkg/tf/writer/locals.go
+++ b/src/pkg/tf/writer/locals.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package writer
 
 import (

--- a/src/pkg/tf/writer/locals_test.go
+++ b/src/pkg/tf/writer/locals_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package writer
 
 import (

--- a/src/pkg/transporthelper/kitapi.go
+++ b/src/pkg/transporthelper/kitapi.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package transporthelper
 
 import (

--- a/src/pkg/transporthelper/server.go
+++ b/src/pkg/transporthelper/server.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package transporthelper
 
 import (

--- a/src/pkg/utils/cty.go
+++ b/src/pkg/utils/cty.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/src/pkg/utils/cty_test.go
+++ b/src/pkg/utils/cty_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/src/pkg/utils/retry.go
+++ b/src/pkg/utils/retry.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/src/pkg/utils/retry_test.go
+++ b/src/pkg/utils/retry_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/src/pkg/utils/vt10x.go
+++ b/src/pkg/utils/vt10x.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/src/pkg/utils/vt10x_test.go
+++ b/src/pkg/utils/vt10x_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (


### PR DESCRIPTION
Initial add of copyright headers to all files using the copywrite
utility.

Added job to pr-check GH action to check for header compliance on
each PR.
