### PR TITLE
TER-236 set module namespace from config

### DIFF
--- a/build/terrarium-api-test-run-pr.yml
+++ b/build/terrarium-api-test-run-pr.yml
@@ -87,8 +87,8 @@ stages:
             cd terrarium
             go env -w GO111MODULE=on
             go env -w GOPRIVATE=github.com/cldcvr/*
-            make docker-init docker-run
-            make docker-harvest
+            make docker-init
+            make docker-build docker-run docker-harvest
           env:
             PM_GIT_TOKEN: $(PM_GIT_TOKEN)
             GIT_TOKEN: $(GIT_TOKEN)

--- a/src/api/internal/config/defaults.yaml
+++ b/src/api/internal/config/defaults.yaml
@@ -32,5 +32,8 @@ log:
   pretty_print: false   # format the text log using colors and indentation etc.
 
 server:
-  http_port: 3000
-  grpc_port: 10000
+  http_port: 3000   # port to bind for running new http server
+  grpc_port: 10000  # port to bind for running new gRPC server
+
+farm:
+  default: github.com/cldcvr/terrarium-farm  # link to the farm repo being utilized

--- a/src/api/internal/config/farm.go
+++ b/src/api/internal/config/farm.go
@@ -1,0 +1,8 @@
+package config
+
+import "github.com/cldcvr/terrarium/src/pkg/confighelper"
+
+// FarmDefault link to the farm repo being utilized
+func FarmDefault() string {
+	return confighelper.MustGetString("farm.default")
+}

--- a/src/api/service/terrariumsrv/module_query.go
+++ b/src/api/service/terrariumsrv/module_query.go
@@ -3,6 +3,7 @@ package terrariumsrv
 import (
 	"context"
 
+	"github.com/cldcvr/terrarium/src/api/internal/config"
 	"github.com/cldcvr/terrarium/src/pkg/db"
 	"github.com/cldcvr/terrarium/src/pkg/pb/terrariumpb"
 	"github.com/rotisserie/eris"
@@ -21,7 +22,7 @@ func (s Service) ListModules(ctx context.Context, req *terrariumpb.ListModulesRe
 		return nil, eris.Wrapf(ErrInvalidRequest, "got page size: %d", req.Page.Size)
 	}
 
-	req.Namespaces = append(req.Namespaces, "farm_repo")
+	req.Namespaces = append(req.Namespaces, config.FarmDefault())
 	result, err := s.db.QueryTFModules(
 		db.ModuleSearchFilter(req.Search),
 		db.PopulateModuleMappingsFilter(req.PopulateMappings),

--- a/src/cli/cmd/harvest/dependencies/cmd.go
+++ b/src/cli/cmd/harvest/dependencies/cmd.go
@@ -25,7 +25,7 @@ var cmd = &cobra.Command{
   			terrarium dependencies --dir /path/to/yaml/files
 
 		Please ensure that the provided directory contains valid YAML or YML files with the appropriate structure to avoid any errors.
-		`),
+	`),
 }
 
 func init() {

--- a/src/cli/cmd/harvest/dependencies/dependencies.go
+++ b/src/cli/cmd/harvest/dependencies/dependencies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cldcvr/terrarium/src/pkg/metadata/dependency"
 	"github.com/cldcvr/terrarium/src/pkg/metadata/taxonomy"
 	"github.com/google/uuid"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v2"
 )
 
@@ -44,7 +45,7 @@ func processYAMLData(g db.DB, path string, data []byte) error {
 
 	err := yaml.Unmarshal(data, &yamlData)
 	if err != nil {
-		return fmt.Errorf("error parsing YAML file %s: %w", path, err)
+		return eris.Wrapf(err, "error parsing YAML file %s", path)
 	}
 
 	for _, dep := range yamlData["dependency-interfaces"] {
@@ -79,7 +80,7 @@ func processYAMLData(g db.DB, path string, data []byte) error {
 		// Call CreateDependencyInterface with the updated Dependency object
 		_, err = g.CreateDependencyInterface(dbDep)
 		if err != nil {
-			return fmt.Errorf("error updating the database: %w", err)
+			return eris.Wrap(err, "error updating the database")
 		}
 	}
 	return nil

--- a/src/cli/cmd/harvest/modules/modules.go
+++ b/src/cli/cmd/harvest/modules/modules.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
+	cliconfig "github.com/cldcvr/terrarium/src/cli/internal/config"
 	"github.com/cldcvr/terrarium/src/pkg/db"
 )
 
@@ -76,6 +77,7 @@ func toTFModule(config *tfconfig.Module) *db.TFModule {
 	record := db.TFModule{
 		ModuleName: config.Path,
 		Source:     config.Path,
+		Namespace:  cliconfig.FarmDefault(),
 	}
 	if config.Metadata != nil {
 		record.ModuleName = config.Metadata.Name

--- a/src/cli/cmd/query/modules/modules.go
+++ b/src/cli/cmd/query/modules/modules.go
@@ -46,7 +46,7 @@ func addFlags() {
 
 	modulesCmd.Flags().StringVarP(&flagOutputFormat, "output", "o", "table", "Output format (json or table)")
 
-	modulesCmd.Flags().StringSliceVarP(&flagNamespaces, "namespaces", "n", []string{}, "namespaces filter - farm_repo will always be included")
+	modulesCmd.Flags().StringSliceVarP(&flagNamespaces, "namespaces", "n", []string{}, "namespaces filter - farm repo will always be included")
 }
 
 func listModules(cmd *cobra.Command, args []string) error {
@@ -59,7 +59,7 @@ func listModules(cmd *cobra.Command, args []string) error {
 		Size:  flagPageSize,
 		Index: flagPageIndex,
 	}
-	flagNamespaces = append(flagNamespaces, "farm_repo")
+	flagNamespaces = append(flagNamespaces, config.FarmDefault())
 	result, err := g.QueryTFModules(
 		db.ModuleSearchFilter(flagSearchText),
 		db.PopulateModuleMappingsFilter(flagPopulateMappings),

--- a/src/cli/cmd/query/modules/modules_test.go
+++ b/src/cli/cmd/query/modules/modules_test.go
@@ -35,7 +35,7 @@ func Test_CmdModules(t *testing.T) {
 				Version:     "1",
 				Source:      "/Users/xyz/abc/tf-dir",
 				Description: "",
-				Namespace:   "farm_repo",
+				Namespace:   config.FarmDefault(),
 			},
 		}, nil)
 	config.SetDBMocks(mockDB)
@@ -53,7 +53,7 @@ func Test_CmdModules(t *testing.T) {
 				cmd.SetArgs(args)
 			},
 			ValidateOutput: func(ctx context.Context, t *testing.T, cmdOpts clitesting.CmdOpts, output []byte) bool {
-				expectedOutput := "{\n \"modules\": [\n  {\n   \"id\": \"" + mockUuid1.String() + "\",\n   \"taxonomy_id\": \"00000000-0000-0000-0000-000000000000\",\n   \"module_name\": \"Rds\",\n   \"source\": \"/Users/xyz/abc/tf-dir\",\n   \"version\": \"1\",\n   \"namespace\": \"farm_repo\"\n  }\n ],\n \"page\": {\n  \"size\": 100\n }\n}"
+				expectedOutput := "{\n \"modules\": [\n  {\n   \"id\": \"" + mockUuid1.String() + "\",\n   \"taxonomy_id\": \"00000000-0000-0000-0000-000000000000\",\n   \"module_name\": \"Rds\",\n   \"source\": \"/Users/xyz/abc/tf-dir\",\n   \"version\": \"1\",\n   \"namespace\": \"" + config.FarmDefault() + "\"\n  }\n ],\n \"page\": {\n  \"size\": 100\n }\n}"
 				return assert.Equal(t, expectedOutput, string(output))
 			},
 		},
@@ -64,7 +64,7 @@ func Test_CmdModules(t *testing.T) {
 				cmd.SetArgs(args)
 			},
 			ValidateOutput: func(ctx context.Context, t *testing.T, cmdOpts clitesting.CmdOpts, output []byte) bool {
-				expectedOutput := "  ID                                    MODULE NAME  SOURCE                 VERSION  NAMESPACE  \n  " + mockUuid1.String() + "  Rds          /Users/xyz/abc/tf-dir  1        farm_repo  \n"
+				expectedOutput := "  ID                                    MODULE NAME  SOURCE                 VERSION  NAMESPACE                         \n  " + mockUuid1.String() + "  Rds          /Users/xyz/abc/tf-dir  1        " + config.FarmDefault() + "  \n"
 				return assert.Equal(t, expectedOutput, string(output))
 			},
 		},
@@ -75,7 +75,7 @@ func Test_CmdModules(t *testing.T) {
 				cmd.SetArgs(args)
 			},
 			ValidateOutput: func(ctx context.Context, t *testing.T, cmdOpts clitesting.CmdOpts, output []byte) bool {
-				expectedOutput := "{\n \"modules\": [\n  {\n   \"id\": \"" + mockUuid1.String() + "\",\n   \"taxonomy_id\": \"00000000-0000-0000-0000-000000000000\",\n   \"module_name\": \"Rds\",\n   \"source\": \"/Users/xyz/abc/tf-dir\",\n   \"version\": \"1\",\n   \"namespace\": \"farm_repo\"\n  }\n ],\n \"page\": {\n  \"size\": 5\n }\n}"
+				expectedOutput := "{\n \"modules\": [\n  {\n   \"id\": \"" + mockUuid1.String() + "\",\n   \"taxonomy_id\": \"00000000-0000-0000-0000-000000000000\",\n   \"module_name\": \"Rds\",\n   \"source\": \"/Users/xyz/abc/tf-dir\",\n   \"version\": \"1\",\n   \"namespace\": \"" + config.FarmDefault() + "\"\n  }\n ],\n \"page\": {\n  \"size\": 5\n }\n}"
 				return assert.Equal(t, expectedOutput, string(output))
 			},
 		},

--- a/src/cli/internal/config/defaults.yaml
+++ b/src/cli/internal/config/defaults.yaml
@@ -32,3 +32,6 @@ log:
 
 terraform:
   plugin_cache_dir: "~/.terraform.d/plugin-cache"
+
+farm:
+  default: github.com/cldcvr/terrarium-farm  # link of the farm repo to use by default

--- a/src/cli/internal/config/farm.go
+++ b/src/cli/internal/config/farm.go
@@ -1,0 +1,8 @@
+package config
+
+import "github.com/cldcvr/terrarium/src/pkg/confighelper"
+
+// FarmDefault link of the farm repo to use by default
+func FarmDefault() string {
+	return confighelper.MustGetString("farm.default")
+}

--- a/src/pkg/db/module.go
+++ b/src/pkg/db/module.go
@@ -19,7 +19,7 @@ type TFModule struct {
 	ModuleName  string
 	Source      string  `gorm:"uniqueIndex:module_unique"`
 	Version     Version `gorm:"uniqueIndex:module_unique"`
-	Namespace   string  `gorm:"default:'farm_repo'"`
+	Namespace   string
 	Description string
 	TaxonomyID  uuid.UUID `gorm:"default:null"`
 

--- a/src/pkg/db/utils.go
+++ b/src/pkg/db/utils.go
@@ -67,8 +67,8 @@ type entity interface {
 }
 
 func createOrUpdate[T entity](g *gorm.DB, e T, uniqueFields []string) (uuid.UUID, error) {
-	res := e.GetCondition()
-	err := g.First(res, e.GetCondition()).Error
+	res := Model{}
+	err := g.Model(e).Where(e.GetCondition()).First(&res).Error
 	if err != nil && !IsNotFoundError(err) {
 		return uuid.Nil, err
 	}


### PR DESCRIPTION
this fixes issue an issue where namespace was not getting updated it was because the db migration was not adding the default namespace value to the schema.

now, instead of relying on the db column default, we set the default namespace as farm repo path and initialize it in the config so that in future, this can be set to a custom value for an org.